### PR TITLE
refactor: fix type errors, dead code, and a resource leak; modernize typing

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,8 +5,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-from openai import OpenAI
-
 from youtube_shorts_gen.pipelines.ai_content_pipeline import run_ai_content_pipeline
 from youtube_shorts_gen.pipelines.internet_content_pipeline import (
     run_internet_content_pipeline,
@@ -214,11 +212,10 @@ def _run_timelapse_pipeline(run_dir: str) -> dict[str, Any]:
                 "final_video_path": video_path,
                 "message": f"Time-lapse video created successfully: {video_path}"
             }
-        else:
-            return {
-                "success": False,
-                "error": "Failed to create time-lapse video"
-            }
+        return {
+            "success": False,
+            "error": "Failed to create time-lapse video"
+        }
     
     except Exception as e:
         logging.exception("Error in time-lapse pipeline: %s", e)

--- a/tests/test_video_creation_pipeline.py
+++ b/tests/test_video_creation_pipeline.py
@@ -20,7 +20,6 @@ from youtube_shorts_gen.content.script_and_image_from_internet import (
     ScriptAndImageFromInternet,
 )
 from youtube_shorts_gen.media.paragraph_processor import ParagraphProcessor
-from youtube_shorts_gen.media.text_processor import TextProcessor
 
 
 class TestVideoCreationPipeline(unittest.TestCase):

--- a/tests/test_youtube_script_gen.py
+++ b/tests/test_youtube_script_gen.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 # Set up logging
 log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/test_youtube_transcript_pipeline.py
+++ b/tests/test_youtube_transcript_pipeline.py
@@ -1,12 +1,13 @@
 """Tests for the YouTube transcript pipeline."""
 
-from unittest.mock import patch, MagicMock
-import pytest
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
 from youtube_shorts_gen.content.transcript_segmenter import TranscriptSegmenter
 from youtube_shorts_gen.pipelines.youtube_transcript_pipeline import (
     run_youtube_transcript_pipeline,
-    YouTubeTranscriptScraper,
 )
 from youtube_shorts_gen.scrapers.youtube_transcript_scraper import (
     YouTubeTranscriptScraper,
@@ -177,7 +178,8 @@ def test_transcript_segmenter(mock_openai_class, mock_segmenter_class):
     
     # Create a real segmenter to test the initialization
     segmenter = TranscriptSegmenter(client=mock_openai)
-    
+    assert segmenter.client is mock_openai
+
     # Test with mock
     transcript = "This is a test transcript."
     segments = mock_segmenter.segment_transcript(transcript)

--- a/youtube_shorts_gen/content/script_and_image_from_internet.py
+++ b/youtube_shorts_gen/content/script_and_image_from_internet.py
@@ -10,8 +10,8 @@ from youtube_shorts_gen.scrapers.dogdrip import fetch_dogdrip_content
 from youtube_shorts_gen.utils.config import IMAGE_PROMPT_TEMPLATE
 from youtube_shorts_gen.utils.openai_image import (
     generate_image as generate_openai_image,
-    generate_sequential_images,
 )
+from youtube_shorts_gen.utils.openai_image import generate_sequential_images
 
 nltk.download("punkt", quiet=True)
 

--- a/youtube_shorts_gen/content/transcript_segmenter.py
+++ b/youtube_shorts_gen/content/transcript_segmenter.py
@@ -1,7 +1,9 @@
 import logging
 import textwrap
+from typing import Any, cast
 
 from openai import OpenAI
+from openai.types.chat import ChatCompletionMessageParam
 
 
 class TranscriptSegmenter:
@@ -27,7 +29,7 @@ class TranscriptSegmenter:
 
     def _chat_completion(
         self,
-        messages: list[dict],
+        messages: list[dict[str, Any]],
         *,
         temperature: float,
         max_tokens: int,
@@ -36,7 +38,7 @@ class TranscriptSegmenter:
         try:
             response = self.client.chat.completions.create(
                 model=self._MODEL,
-                messages=messages,
+                messages=cast(list[ChatCompletionMessageParam], messages),
                 temperature=temperature,
                 max_tokens=max_tokens,
             )

--- a/youtube_shorts_gen/media/runway.py
+++ b/youtube_shorts_gen/media/runway.py
@@ -35,6 +35,7 @@ class VideoGenerator:
             raise ValueError("RUNWAY_API_KEY is not set in environment variables")
         os.environ["RUNWAYML_API_SECRET"] = RUNWAY_API_KEY
         self.client = RunwayML()
+        self.current_video_id = 0
 
     def _image_to_data_uri(self, image_path: str) -> str:
         """Convert an image to a base64 data URI.
@@ -96,7 +97,12 @@ class VideoGenerator:
 
         return runway_prompt
 
-    def generate(self, image_path: str = None, prompt_text: str = None, duration: float = 5.0) -> str:
+    def generate(
+        self,
+        image_path: str | None = None,
+        prompt_text: str | None = None,
+        duration: float = 5.0,
+    ) -> str:
         """Generate a video from an image and prompt using RunwayML.
 
         Args:
@@ -117,12 +123,12 @@ class VideoGenerator:
         self.current_video_id = int(time.time() * 1000) % 10000
         # Handle default paths for backward compatibility
         if image_path is None:
-            image_path = self.run_dir / "story_image.png"
+            image_file = self.run_dir / "story_image.png"
         else:
-            image_path = Path(image_path)
+            image_file = Path(image_path)
 
-        if not image_path.exists():
-            raise FileNotFoundError(f"Image file not found: {image_path}")
+        if not image_file.exists():
+            raise FileNotFoundError(f"Image file not found: {image_file}")
             
         # Get prompt text either from parameter or default file
         if prompt_text is None:
@@ -137,7 +143,7 @@ class VideoGenerator:
         runway_prompt = self._create_runway_prompt(story_text)
 
         # Convert image to data URI
-        image_data_uri = self._image_to_data_uri(str(image_path))
+        image_data_uri = self._image_to_data_uri(str(image_file))
 
         # Send request to RunwayML with fixed duration (Runway API limit)
         # The target duration parameter is stored but not used here
@@ -167,8 +173,7 @@ class VideoGenerator:
             video_url = task.output[0]
             output_path = self._download_video(video_url)
             return str(output_path)
-        else:
-            raise RuntimeError(f"Video generation failed: status = {task.status}")
+        raise RuntimeError(f"Video generation failed: status = {task.status}")
 
     def _download_video(self, video_url: str) -> Path:
         """Download a video from URL and save it to the run directory.
@@ -189,14 +194,13 @@ class VideoGenerator:
         # Use the current_video_id to create a unique filename
         output_path = videos_dir / f"runway_video_{self.current_video_id}.mp4"
 
-        response = requests.get(video_url, stream=True)
-        if response.status_code == 200:
+        with requests.get(video_url, stream=True) as response:
+            if response.status_code != 200:
+                raise ConnectionError(
+                    f"Video download failed: status code = {response.status_code}"
+                )
             with open(output_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):
                     f.write(chunk)
-            logging.info("Video download complete: %s", output_path)
-            return output_path
-        else:
-            raise ConnectionError(
-                f"Video download failed: status code = {response.status_code}"
-            )
+        logging.info("Video download complete: %s", output_path)
+        return output_path

--- a/youtube_shorts_gen/pipelines/ai_content_pipeline.py
+++ b/youtube_shorts_gen/pipelines/ai_content_pipeline.py
@@ -3,6 +3,8 @@
 import logging
 from typing import Any
 
+from openai import OpenAI
+
 from youtube_shorts_gen.content.script_and_image_gen import ScriptAndImageGenerator
 from youtube_shorts_gen.media.runway import VideoGenerator
 from youtube_shorts_gen.media.tts_generator import TTSGenerator
@@ -11,15 +13,20 @@ from youtube_shorts_gen.utils.openai_client import get_openai_client
 
 # === Helper functions (Single Responsibility) ===
 
-def _generate_script_and_images(run_dir: str, client) -> dict[str, Any]:
-    """Generate script and images using the LLM and DALLE."""
+def _generate_script_and_images(run_dir: str, client: OpenAI) -> dict[str, Any]:
+    """Generate script and images using the LLM and DALLE.
+
+    ``ScriptAndImageGenerator.run`` writes the story and a single image to
+    ``run_dir`` and returns nothing, raising on failure. We surface the produced
+    artifact paths so downstream steps and callers can reference them.
+    """
     generator = ScriptAndImageGenerator(run_dir, client)
-    result: dict[str, Any] = generator.run()
-    logging.info(
-        "[AI Pipeline] Generated %d images for story",
-        len(result.get("image_paths", []))
-    )
-    return result
+    generator.run()
+    logging.info("[AI Pipeline] Generated story and image for run %s", run_dir)
+    return {
+        "story_path": str(generator.prompt_path),
+        "image_paths": [str(generator.image_path)],
+    }
 
 
 def _generate_ai_video(run_dir: str) -> dict[str, Any]:

--- a/youtube_shorts_gen/pipelines/internet_content_pipeline.py
+++ b/youtube_shorts_gen/pipelines/internet_content_pipeline.py
@@ -1,9 +1,8 @@
 import logging
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 
 from mutagen.mp3 import MP3
-from openai import OpenAI
 
 from youtube_shorts_gen.content.script_and_image_from_internet import (
     ScriptAndImageFromInternet,
@@ -14,9 +13,7 @@ from youtube_shorts_gen.media.video_assembler import VideoAssembler
 from youtube_shorts_gen.utils.openai_client import get_openai_client
 
 
-
-
-def _generate_tts_and_get_durations(run_dir: str, sentences: list[str]) -> Tuple[list[str], list[float]]:
+def _generate_tts_and_get_durations(run_dir: str, sentences: list[str]) -> tuple[list[str], list[float]]:
     """Generate TTS audio for each sentence and measure their durations.
     
     Args:
@@ -78,7 +75,7 @@ def _generate_synced_video_segments(
     looped_videos_dir.mkdir(exist_ok=True)
     
     for i, (sentence, image_path, audio_path, duration) in enumerate(
-        zip(sentences, image_paths, audio_paths, audio_durations)
+        zip(sentences, image_paths, audio_paths, audio_durations, strict=False)
     ):
         try:
             # Generate base silent video with Runway (will be fixed duration, e.g., 4-5 seconds)

--- a/youtube_shorts_gen/pipelines/timelapse_pipeline.py
+++ b/youtube_shorts_gen/pipelines/timelapse_pipeline.py
@@ -10,15 +10,14 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import List, Tuple, Optional
 
 from openai import OpenAI
 
 from youtube_shorts_gen.media.video_assembler import VideoAssembler
-from youtube_shorts_gen.utils.image_utils import overlay_text_on_images
-from youtube_shorts_gen.utils.frame_interpolator import interpolate_between
-from youtube_shorts_gen.utils.openai_image import generate_sequential_images
 from youtube_shorts_gen.upload.upload_to_youtube import YouTubeUploader
+from youtube_shorts_gen.utils.frame_interpolator import interpolate_between
+from youtube_shorts_gen.utils.image_utils import overlay_text_on_images
+from youtube_shorts_gen.utils.openai_image import generate_sequential_images
 
 # Constants
 TIMELAPSE_IMAGES_DIR = "timelapse_images"
@@ -39,10 +38,10 @@ def run_timelapse_pipeline(
     transition_duration: float = DEFAULT_TRANSITION_DURATION,
     frame_duration: float = DEFAULT_FRAME_DURATION,
     transition_type: str = DEFAULT_TRANSITION_TYPE,
-    music_path: Optional[str] = None,
+    music_path: str | None = None,
     upload_to_youtube: bool = True,
-    video_title: Optional[str] = None,
-    video_description: Optional[str] = None,
+    video_title: str | None = None,
+    video_description: str | None = None,
     num_inter_frames: int =3,  # Use at most 3 interpolated frames
     inter_frame_duration: float = 0.033,  # 30 fps -> ~0.099s total for 3 frames
     main_frame_duration: float = 0.5,
@@ -92,8 +91,8 @@ def run_timelapse_pipeline(
     image_paths = overlay_text_on_images(image_paths, [str(y) for y in years], overlay_dir)
 
     # Insert interpolated frames between each consecutive pair for smoother motion
-    enriched_image_paths: List[str] = []
-    frame_durations: List[float] = []
+    enriched_image_paths: list[str] = []
+    frame_durations: list[float] = []
     for idx in range(len(image_paths) - 1):
         # Original yearly image
         enriched_image_paths.append(image_paths[idx])
@@ -148,8 +147,8 @@ def run_timelapse_pipeline(
 
 
 def _generate_year_prompts(
-    base_prompt: str, years: List[int], images_dir: Path
-) -> Tuple[List[str], List[Path]]:
+    base_prompt: str, years: list[int], images_dir: Path
+) -> tuple[list[str], list[Path]]:
     """Generate prompts and output paths for each year.
     
     Args:
@@ -182,13 +181,13 @@ def _generate_year_prompts(
 
 def _create_timelapse_video(
     run_dir: Path,
-    image_paths: List[str],
+    image_paths: list[str],
     fps: int,
     transition_duration: float,
     frame_duration: float,
     transition_type: str,
-    music_path: Optional[str],
-    frame_durations: Optional[List[float]] = None,
+    music_path: str | None,
+    frame_durations: list[float] | None = None,
 ) -> str:
     """Create a time-lapse video from the generated images with smooth transitions.
     
@@ -230,7 +229,7 @@ def _upload_to_youtube(
     video_path: str, 
     title: str, 
     description: str,
-    tags: Optional[List[str]] = None
+    tags: list[str] | None = None
 ) -> bool:
     """Upload the video to YouTube.
     
@@ -271,10 +270,8 @@ def _upload_to_youtube(
             if video_url:
                 logging.info("Video successfully uploaded to YouTube: %s", video_url)
                 return True
-            else:
-                logging.error("Failed to upload video to YouTube")
-                return False
-            
+            logging.error("Failed to upload video to YouTube")
+            return False
     except Exception as e:
         logging.error("Error uploading to YouTube: %s", e)
         return False

--- a/youtube_shorts_gen/pipelines/youtube_transcript_pipeline.py
+++ b/youtube_shorts_gen/pipelines/youtube_transcript_pipeline.py
@@ -9,10 +9,10 @@ from typing import Any
 from youtube_shorts_gen.content.transcript_segmenter import TranscriptSegmenter
 from youtube_shorts_gen.media.tts_generator import TTSGenerator
 from youtube_shorts_gen.media.video_assembler import VideoAssembler
-from youtube_shorts_gen.utils.config import MAX_RUNWAY_VIDEOS_PER_SEGMENT
 from youtube_shorts_gen.scrapers.youtube_transcript_scraper import (
     YouTubeTranscriptScraper,
 )
+from youtube_shorts_gen.utils.config import MAX_RUNWAY_VIDEOS_PER_SEGMENT
 from youtube_shorts_gen.utils.openai_client import (
     get_openai_client,  # remain for run function to create client
 )

--- a/youtube_shorts_gen/scrapers/youtube_transcript_scraper.py
+++ b/youtube_shorts_gen/scrapers/youtube_transcript_scraper.py
@@ -15,9 +15,14 @@ class YouTubeTranscriptScraper(ContentScraper):
         self.youtube_url = ""
         self.transcript_api = YouTubeTranscriptApi()
 
-    def fetch_content(self, youtube_url: str) -> str | None:
-        """Returns the full transcript or ``None`` if unavailable."""
-        return self.fetch_transcript(youtube_url)
+    def fetch_content(self) -> list[str]:
+        """Return the stored video's transcript as a single-item list.
+
+        Satisfies the :class:`ContentScraper` interface. Callers that need the
+        raw transcript string should use :meth:`fetch_transcript` directly.
+        """
+        transcript = self.fetch_transcript(self.youtube_url)
+        return [transcript] if transcript else []
 
     def fetch_transcript(self, youtube_url: str) -> str | None:
         """Fetches and combines all transcript segments for a YouTube video."""
@@ -69,7 +74,7 @@ class YouTubeTranscriptScraper(ContentScraper):
             return len(obj) > 0
         return True
 
-    def _try_auto_captions(self, video_id: str):
+    def _try_auto_captions(self, video_id: str) -> Any:
         """
         Prefers auto-generated captions; otherwise returns first non-empty transcript.
         """

--- a/youtube_shorts_gen/utils/frame_interpolator.py
+++ b/youtube_shorts_gen/utils/frame_interpolator.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import List
 
 import cv2  # type: ignore
 import numpy as np
@@ -34,7 +33,7 @@ def interpolate_between(
     img2_path: str | Path,
     num_inter_frames: int = 32,
     output_dir: str | Path | None = None,
-) -> List[str]:
+) -> list[str]:
     """Generate *num_inter_frames* images between *img1* and *img2*.
 
     Returns list of output image paths (in order). If interpolation fails,
@@ -61,7 +60,7 @@ def interpolate_between(
         # Resize the second image to match the first
         img1 = cv2.resize(img1, (img0.shape[1], img0.shape[0]))
 
-    outputs: List[str] = []
+    outputs: list[str] = []
     for i in range(1, num_inter_frames + 1):
         # Calculate blending factor
         alpha = i / (num_inter_frames + 1)

--- a/youtube_shorts_gen/utils/image_utils.py
+++ b/youtube_shorts_gen/utils/image_utils.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -61,7 +61,7 @@ def overlay_text_on_images(image_paths: Sequence[str], texts: Sequence[str], out
         except Exception:
             continue
 
-    for img_path, text in zip(image_paths, texts):
+    for img_path, text in zip(image_paths, texts, strict=False):
         try:
             with Image.open(img_path).convert("RGBA") as im:
                 draw = ImageDraw.Draw(im)
@@ -70,14 +70,8 @@ def overlay_text_on_images(image_paths: Sequence[str], texts: Sequence[str], out
                 font = ImageFont.truetype(base_font_path, dynamic_font_size) if base_font_path else _load_font(dynamic_font_size)
                 stroke_width = max(2, dynamic_font_size // 20)
                 # Pillow 10 removed textsize; use textbbox for accurate dimensions
-                # If default font (fixed small size), dynamically increase font using heuristic
-                if isinstance(font, ImageFont.ImageFont) and font == ImageFont.load_default():
-                    # Basic heuristic to scale using multiple draws
-                    scale_factor = font_size // 10  # crude scaling
-                    text_scaled = " ".join(list(text)) * scale_factor  # widen artificially
                 bbox = draw.textbbox((0, 0), text, font=font)
                 text_width = bbox[2] - bbox[0]
-                text_height = bbox[3] - bbox[1]
                 x = (im.width - text_width) // 2
                 y = 20  # padding from top
                 # Draw the main text in white with no background

--- a/youtube_shorts_gen/utils/openai_image.py
+++ b/youtube_shorts_gen/utils/openai_image.py
@@ -7,11 +7,12 @@ existed in three separate places. Use :func:`generate_image` for single images o
 from __future__ import annotations
 
 import base64
-import logging
-from pathlib import Path
+import contextlib
 import hashlib
 import json
-from typing import TYPE_CHECKING, List, Optional, Dict, Any
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
 
 from youtube_shorts_gen.utils.config import (
     OPENAI_IMAGE_MODEL,
@@ -33,7 +34,7 @@ _CACHE_INDEX_FILE = _CACHE_DIR / "index.json"
 # Load existing index
 if _CACHE_INDEX_FILE.exists():
     try:
-        _CACHE_INDEX: Dict[str, str] = json.loads(_CACHE_INDEX_FILE.read_text())
+        _CACHE_INDEX: dict[str, str] = json.loads(_CACHE_INDEX_FILE.read_text())
     except json.JSONDecodeError:
         _CACHE_INDEX = {}
 else:
@@ -43,7 +44,7 @@ def _make_cache_key(prompt: str, size: str, quality: str, model: str) -> str:
     """Create a stable hash key for an image generation request."""
     return hashlib.sha256(f"{model}|{size}|{quality}|{prompt}".encode()).hexdigest()
 
-def _get_cached_path(key: str) -> Optional[Path]:
+def _get_cached_path(key: str) -> Path | None:
     path_str = _CACHE_INDEX.get(key)
     if path_str:
         path = Path(path_str)
@@ -53,11 +54,9 @@ def _get_cached_path(key: str) -> Optional[Path]:
 
 def _store_cache(key: str, image_path: Path) -> None:
     _CACHE_INDEX[key] = str(image_path)
-    # Persist index to disk (best-effort)
-    try:
+    # Persist index to disk (best-effort); caching should never crash
+    with contextlib.suppress(Exception):
         _CACHE_INDEX_FILE.write_text(json.dumps(_CACHE_INDEX))
-    except Exception:  # pragma: no cover – caching should never crash
-        pass
 
 
 def _resolve_size() -> str:
@@ -100,8 +99,8 @@ def generate_image(client: OpenAI, prompt: str, output_path: Path) -> str:
         response = client.images.generate(
             model=OPENAI_IMAGE_MODEL,
             prompt=prompt,
-            size=_resolve_size(),
-            quality=OPENAI_IMAGE_QUALITY,
+            size=cast(Any, _resolve_size()),
+            quality=cast(Any, OPENAI_IMAGE_QUALITY),
             n=1,
         )
 
@@ -122,8 +121,8 @@ def generate_image(client: OpenAI, prompt: str, output_path: Path) -> str:
 
 
 def generate_sequential_images(
-    client: OpenAI, prompts: List[str], output_paths: List[Path]
-) -> List[str]:
+    client: OpenAI, prompts: list[str], output_paths: list[Path]
+) -> list[str]:
     """Generate a sequence of images with visual continuity using OpenAI's multi-turn API.
     
     This function creates a series of images where each new image builds upon the previous one,
@@ -142,9 +141,9 @@ def generate_sequential_images(
         return [""] * len(output_paths) if output_paths else []
         
     image_paths = []
-    previous_image_id: Optional[str] = None
-    
-    for i, (prompt, output_path) in enumerate(zip(prompts, output_paths)):
+    previous_image_id: str | None = None
+
+    for prompt, output_path in zip(prompts, output_paths, strict=False):
         try:
             # Use OpenAI multi-turn image generation (gpt-image-1) for frame-to-frame consistency
             cache_key = _make_cache_key(prompt, _resolve_size(), OPENAI_IMAGE_QUALITY, OPENAI_IMAGE_MODEL)
@@ -156,7 +155,7 @@ def generate_sequential_images(
                 previous_image_id = None  # Cannot pass ID; but style consistency via cache
                 continue
 
-            generate_kwargs: Dict[str, Any] = {
+            generate_kwargs: dict[str, Any] = {
                 "model": OPENAI_IMAGE_MODEL,
                 "prompt": prompt,
                 "size": _resolve_size(),


### PR DESCRIPTION
## What changed

Behavior-preserving cleanup across the source tree. No working runtime path changes shape.

**Genuine source fixes** (resolve 11 pyright errors + several ruff findings):
- **`media/runway.py`** — `generate()` params were typed `str` but defaulted to `None`; retyped to `str | None`. Used a distinct local `image_file: Path` so the parameter type is no longer contradicted by reassignment. Wrapped the streamed video download in a `with requests.get(...)` context manager so the HTTP connection is always closed (previously leaked on both success and the non-200 path). Declared `current_video_id` in `__init__`.
- **`pipelines/ai_content_pipeline.py`** — `ScriptAndImageGenerator.run()` returns `None`, so the old `result.get("image_paths", ...)` would raise `AttributeError` at runtime. Now builds the artifact-paths dict from the generator's known output paths. Typed the `client` param as `OpenAI`.
- **`content/transcript_segmenter.py`** — cast chat messages to `ChatCompletionMessageParam` so the SDK call type-checks.
- **`scrapers/youtube_transcript_scraper.py`** — `fetch_content()` now matches the `ContentScraper` interface (the previous URL-taking override was unused and violated LSP). Annotated `_try_auto_captions()` return as `Any` so `.snippets` access type-checks.
- **`utils/image_utils.py`** — removed dead `text_scaled` / `text_height` computations (assigned, never used).

**Mechanical (ruff autofix):** modernized typing (`List`/`Tuple`/`Dict`/`Optional` → builtins and `X | Y`), sorted imports, dropped unused imports, replaced `try/except/pass` with `contextlib.suppress`, removed unnecessary `else`-after-`return`, added explicit `strict=False` to `zip()` calls, dropped an unused loop variable.

## Why behavior-preserving

- Typing changes (`X | None`, builtin generics, casts) are annotations only — no runtime effect.
- The `runway.py` download still raises `ConnectionError` on non-200 and writes identical bytes; the only change is guaranteed response cleanup.
- The `ai_content_pipeline.py` change replaces a code path that could only ever crash (`None.get(...)`) with one that returns the real artifact paths; no previously-working behavior relied on the broken branch.
- `fetch_content` on the YouTube scraper had no callers (the pipeline and tests use `fetch_transcript`), so changing it to satisfy the base interface affects no real path.
- Removed code in `image_utils.py` was assigned-but-unused; no draw call referenced it.
- Dead/unused-import and `else`-after-`return` removals don't alter control flow.
- The full passing test set is unchanged.

## Verification

Environment: Python 3.12 venv (repo declares `>=3.13`, unavailable here), all runtime deps installed, plus `ruff`/`pyright`/`pytest`. No ffmpeg/poetry on the machine. Static checks + unit tests only — no paid AI calls, no media render, no uploads.

| Check | Before | After |
|-------|--------|-------|
| ruff | 160 errors | 100 errors (all remaining = pre-existing `E501` line-length) |
| pyright | 13 errors | 2 errors (both in a pre-existing stale test referencing a removed `split_into_sentences` method) |
| pytest | 11 passed / 7 failed / 1 error | 11 passed / 7 failed / 1 error (identical set) |

The 7 failing tests + 1 error are pre-existing and unrelated to this change: they exercise removed/renamed APIs (stale tests) or require `OPENAI_API_KEY` in the environment. The set of passing tests is byte-for-byte identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)