### PR TITLE
test: expand coverage 42%->73% across media/upload/utils

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -75,11 +75,109 @@ version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
     {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
 ]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "charset-normalizer"
@@ -87,7 +185,7 @@ version = "3.4.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
     {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
@@ -212,6 +310,191 @@ files = [
 markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "coverage"
+version = "7.14.1"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf"},
+    {file = "coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550"},
+    {file = "coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b"},
+    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332"},
+    {file = "coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59"},
+    {file = "coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253"},
+    {file = "coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f"},
+    {file = "coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860"},
+    {file = "coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df"},
+    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9"},
+    {file = "coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548"},
+    {file = "coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e"},
+    {file = "coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3"},
+    {file = "coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c"},
+    {file = "coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad"},
+    {file = "coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02"},
+    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a"},
+    {file = "coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1"},
+    {file = "coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e"},
+    {file = "coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a"},
+    {file = "coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793"},
+    {file = "coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be"},
+    {file = "coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d"},
+    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33"},
+    {file = "coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c"},
+    {file = "coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416"},
+    {file = "coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42"},
+    {file = "coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d"},
+    {file = "coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2"},
+    {file = "coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69"},
+    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54"},
+    {file = "coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1"},
+    {file = "coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce"},
+    {file = "coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1"},
+    {file = "coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee"},
+    {file = "coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851"},
+    {file = "coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4"},
+    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d"},
+    {file = "coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee"},
+    {file = "coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7"},
+    {file = "coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343"},
+    {file = "coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1"},
+    {file = "coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65"},
+    {file = "coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890"},
+    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd"},
+    {file = "coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e"},
+    {file = "coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c"},
+    {file = "coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af"},
+    {file = "coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2"},
+    {file = "coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be"},
+]
+
+[package.extras]
+toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.9"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\""
+files = [
+    {file = "cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c"},
+    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5"},
+    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321"},
+    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74"},
+    {file = "cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4"},
+    {file = "cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7"},
+    {file = "cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336"},
+    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057"},
+    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae"},
+    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c"},
+    {file = "cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f"},
+    {file = "cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12"},
+    {file = "cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a"},
+    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239"},
+    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c"},
+    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4"},
+    {file = "cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd"},
+    {file = "cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8"},
+    {file = "cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855"},
+    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b"},
+    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13"},
+    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb"},
+    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355"},
+    {file = "cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a"},
+    {file = "cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+ssh = ["bcrypt (>=3.1.5)"]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 description = "Decorators for Humans"
@@ -249,6 +532,18 @@ files = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.23"
+description = "Docutils -- Python Documentation Utilities"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea"},
+    {file = "docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e"},
+]
+
+[[package]]
 name = "elevenlabs"
 version = "2.51.0"
 description = ""
@@ -270,6 +565,18 @@ websockets = ">=11.0"
 
 [package.extras]
 pyaudio = ["pyaudio (>=0.2.14)"]
+
+[[package]]
+name = "filelock"
+version = "3.29.1"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b"},
+    {file = "filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e"},
+]
 
 [[package]]
 name = "google-api-core"
@@ -473,12 +780,32 @@ socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "id"
+version = "1.6.1"
+description = "A tool for generating OIDC identities"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca"},
+    {file = "id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069"},
+]
+
+[package.dependencies]
+urllib3 = ">=2,<3"
+
+[package.extras]
+dev = ["build", "bump (>=1.3.2)", "id[lint,test]"]
+lint = ["bandit", "interrogate", "mypy", "ruff (<0.14.15)"]
+test = ["coverage[toml]", "pretend", "pytest", "pytest-cov"]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -549,6 +876,88 @@ files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+description = "Utility functions for Python class constructs"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
+files = [
+    {file = "jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"},
+    {file = "jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+description = "Useful decorators and context managers"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
+files = [
+    {file = "jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"},
+    {file = "jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.test (>=5.6.0)", "portend", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+description = "Functools like those found in stdlib"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
+files = [
+    {file = "jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4"},
+    {file = "jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03"},
+]
+
+[package.dependencies]
+more_itertools = "*"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.classes", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\""
+files = [
+    {file = "jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"},
+    {file = "jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"},
+]
+
+[package.extras]
+test = ["async-timeout ; python_version < \"3.11\"", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["trio"]
 
 [[package]]
 name = "jiter"
@@ -649,6 +1058,85 @@ files = [
 ]
 
 [[package]]
+name = "keyring"
+version = "25.7.0"
+description = "Store and access your passwords safely."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
+files = [
+    {file = "keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f"},
+    {file = "keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b"},
+]
+
+[package.dependencies]
+"jaraco.classes" = "*"
+"jaraco.context" = "*"
+"jaraco.functools" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+completion = ["shtab (>=1.1.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
+type = ["pygobject-stubs", "pytest-mypy (>=1.0.1)", "shtab", "types-pywin32"]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
+    {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins (>=0.5.0)"]
+profiling = ["gprof2dot"]
+rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-timeout", "requests"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
+files = [
+    {file = "more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192"},
+    {file = "more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d"},
+]
+
+[[package]]
 name = "moviepy"
 version = "2.1.2"
 description = "Video editing with Python"
@@ -684,6 +1172,43 @@ groups = ["main"]
 files = [
     {file = "mutagen-1.47.0-py3-none-any.whl", hash = "sha256:edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719"},
     {file = "mutagen-1.47.0.tar.gz", hash = "sha256:719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99"},
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.5"
+description = "Python binding to Ammonia HTML sanitizer Rust crate"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "nh3-0.3.5-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:23a312224875f72cd16bde417f49071451877e29ef646a60e50fcb69407cc18a"},
+    {file = "nh3-0.3.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:387abd011e81959d5a35151a11350a0795c6edeb53ebfa02d2e882dc01299263"},
+    {file = "nh3-0.3.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:48f45e3e914be93a596431aa143dedf1582557bf41a58153c296048d6e3798c9"},
+    {file = "nh3-0.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a09f51806fd51b4fedbf9ea2b61fef388f19aef0d62fe51199d41648be14588"},
+    {file = "nh3-0.3.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c357f1d042c67f135a5e6babb2b0e3b9d9224ff4a3543240f597767b01384ffd"},
+    {file = "nh3-0.3.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:38748140bf76383ab7ce2dce0ad4cb663855d8fbc9098f7f3483673d09616a17"},
+    {file = "nh3-0.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:84bdeb082544fbcb77a12c034dd77d7da0556fdc0727b787eb6214b958c15e29"},
+    {file = "nh3-0.3.5-cp314-cp314t-win32.whl", hash = "sha256:c3aae321f67ae66cff2a627115f106a377d4475d10b0e13d97959a13486b9a88"},
+    {file = "nh3-0.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c88605d8d468f7fc1b31e06129bc91d6c96f6c621776c9b504a0da9beac9df5f"},
+    {file = "nh3-0.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:72c5bdedec27fa33de6a5326346ea8aa3fe54f6ac294d54c4b204fb66a9f1e79"},
+    {file = "nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:acfd354e61accbe4c74f8017c6e397a776916dfe47c48643cf7fd84ade826f93"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:52d877980d7ca01dc3baf3936bf844828bc6f332962227a684ed79c18cce14c3"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:207c01801d3e9bb8ec08f08689346bdd30ce15b8bf60013a925d08b5388962a4"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea232933394d1d58bf7c4bb348dc4660eae6604e1ae81cd2ba6d9ed80d390f3b"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:488928988caad25ba14b1eb5bc74e25e21f3b5e40341d956f3ce4a8bc19460dc"},
+    {file = "nh3-0.3.5-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c069570b06aa848457713ad7af4a9905691291548c4466a9ad78ee95808382b"},
+    {file = "nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4"},
+    {file = "nh3-0.3.5-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:de8e8621853b6470fe928c684ee0d3f39ea8086cebafe4c416486488dea7b68d"},
+    {file = "nh3-0.3.5-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:6ea58cc44d274c643b83547ca9654a0b1a817609b160601356f76a2b744c49ad"},
+    {file = "nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9"},
+    {file = "nh3-0.3.5-cp38-abi3-win32.whl", hash = "sha256:559e4c73b689e9a7aa97ac9760b1bc488038d7c1a575aa4ab5a0e19ee9630c0f"},
+    {file = "nh3-0.3.5-cp38-abi3-win_amd64.whl", hash = "sha256:45e6a65dc88a300a2e3502cb9c8e6d1d6b831d6fba7470643333609c6aab1f30"},
+    {file = "nh3-0.3.5-cp38-abi3-win_arm64.whl", hash = "sha256:8f85285700a18e9f3fc5bff41fe573fa84f81542ef13b48a89f9fecca0474d3b"},
+    {file = "nh3-0.3.5.tar.gz", hash = "sha256:45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8"},
 ]
 
 [[package]]
@@ -995,6 +1520,18 @@ files = [
 tqdm = "*"
 
 [[package]]
+name = "progress"
+version = "1.6.1"
+description = "Easy to use progress bars"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "progress-1.6.1-py3-none-any.whl", hash = "sha256:5239f22f305c12fdc8ce6e0e47f70f21622a935e16eafc4535617112e7c7ea0b"},
+    {file = "progress-1.6.1.tar.gz", hash = "sha256:c1ba719f862ce885232a759eab47971fe74dfc7bb76ab8a51ef5940bad35086c"},
+]
+
+[[package]]
 name = "proto-plus"
 version = "1.26.1"
 description = "Beautiful, Pythonic protocol buffers"
@@ -1057,6 +1594,19 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.6.1,<0.7.0"
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
 
 [[package]]
 name = "pydantic"
@@ -1205,6 +1755,21 @@ files = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyparsing"
 version = "3.2.3"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -1262,6 +1827,26 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "6.3.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749"},
+    {file = "pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.5", extras = ["toml"]}
+pluggy = ">=1.2"
+pytest = ">=6.2.5"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1275,6 +1860,39 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"win32\""
+files = [
+    {file = "pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"},
+    {file = "pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"},
+]
+
+[[package]]
+name = "readme-renderer"
+version = "44.0"
+description = "readme_renderer is a library for rendering readme descriptions for Warehouse"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151"},
+    {file = "readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1"},
+]
+
+[package.dependencies]
+docutils = ">=0.21.2"
+nh3 = ">=0.2.14"
+Pygments = ">=2.5.1"
+
+[package.extras]
+md = ["cmarkgfm (>=0.8.0)"]
 
 [[package]]
 name = "regex"
@@ -1386,7 +2004,7 @@ version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
@@ -1420,6 +2038,55 @@ requests = ">=2.0.0"
 
 [package.extras]
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+description = "A utility belt for advanced users of python-requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["dev"]
+files = [
+    {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
+    {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
+]
+
+[package.dependencies]
+requests = ">=2.0.1,<3.0.0"
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+description = "Validating URI References per RFC 3986"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd"},
+    {file = "rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"},
+]
+
+[package.extras]
+idna2008 = ["idna"]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.9.0"
+groups = ["dev"]
+files = [
+    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
+    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "rsa"
@@ -1484,6 +2151,23 @@ sniffio = "*"
 typing-extensions = ">=4.10,<5"
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\""
+files = [
+    {file = "secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"},
+    {file = "secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be"},
+]
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -1506,6 +2190,26 @@ files = [
     {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
     {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
 ]
+
+[[package]]
+name = "static-ffmpeg"
+version = "2.13"
+description = "Cross platform ffmpeg to work on various systems."
+optional = false
+python-versions = ">=3.6.0"
+groups = ["dev"]
+files = [
+    {file = "static_ffmpeg-2.13-py3-none-any.whl", hash = "sha256:3bed55a7979f9de9d1eec1126b98774a1d41c2e323811f59973d54b9c94d6dac"},
+]
+
+[package.dependencies]
+filelock = "*"
+progress = "*"
+requests = "*"
+twine = ">=3.8.0"
+
+[package.extras]
+test = ["pytest"]
 
 [[package]]
 name = "toml"
@@ -1540,6 +2244,32 @@ discord = ["requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
+
+[[package]]
+name = "twine"
+version = "6.2.0"
+description = "Collection of utilities for publishing packages on PyPI"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8"},
+    {file = "twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf"},
+]
+
+[package.dependencies]
+id = "*"
+keyring = {version = ">=21.2.0", markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\""}
+packaging = ">=24.0"
+readme-renderer = ">=35.0"
+requests = ">=2.20"
+requests-toolbelt = ">=0.8.0,<0.9.0 || >0.9.0"
+rfc3986 = ">=1.4.0"
+rich = ">=12.0.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+keyring = ["keyring (>=21.2.0)"]
 
 [[package]]
 name = "typing-extensions"
@@ -1586,7 +2316,7 @@ version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
@@ -1679,29 +2409,12 @@ files = [
 
 [[package]]
 name = "youtube-transcript-api"
-version = "1.1.0"
-description = "This is an python API which allows you to get the transcripts/subtitles for a given YouTube video. It also works for automatically generated subtitles, supports translating subtitles and it does not require a headless browser, like other selenium based solutions do!"
-optional = false
-python-versions = "<3.14,>=3.8"
-groups = ["main"]
-markers = "python_version == \"3.12\""
-files = [
-    {file = "youtube_transcript_api-1.1.0-py3-none-any.whl", hash = "sha256:876ac42b1e3f8cc99b81d8fd810bd74ed07511e51dff5db50e714e3156ad3595"},
-    {file = "youtube_transcript_api-1.1.0.tar.gz", hash = "sha256:786d9e64bd7fffee0dbc1471a61a798cebdc379b9cf8f7661d3664e831fcc1a5"},
-]
-
-[package.dependencies]
-defusedxml = ">=0.7.1,<0.8.0"
-requests = "*"
-
-[[package]]
-name = "youtube-transcript-api"
 version = "1.2.4"
 description = "This is a python API which allows you to get the transcripts/subtitles for a given YouTube video. It also works for automatically generated subtitles, supports translating subtitles and it does not require a headless browser, like other selenium based solutions do!"
 optional = false
 python-versions = "<3.15,>=3.8"
 groups = ["main"]
-markers = "python_version >= \"3.13\" and python_version < \"3.15\""
+markers = "python_version < \"3.15\""
 files = [
     {file = "youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff"},
     {file = "youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd"},
@@ -1714,4 +2427,4 @@ requests = "*"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "a3d791959ffe334459dc8e6ba552957a1868c6c5e62f4153c12834ffb904e54c"
+content-hash = "3e2ebeb2a4105f0e638d6e29584a62e7bde59ece826d21fc12d2a400a91888d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ packages = [
 ruff = ">=0.5.0,<0.6.0"
 pyright = "^1.1.400"
 pytest = "^8.3.5"
+pytest-cov = "^6.0.0"
+static-ffmpeg = "^2.5"
 toml = "^0.10.2"
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for the test suite."""
 
+import shutil
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -8,6 +9,30 @@ import pytest
 
 # Allow importing the package when tests are run from any working directory.
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _ensure_ffmpeg_on_path() -> None:
+    """Best-effort: make ffmpeg/ffprobe discoverable for the video tests.
+
+    Uses a system install if present, else the optional ``static_ffmpeg`` dev
+    dependency. Tests that need ffmpeg skip themselves when neither is found.
+    """
+    if shutil.which("ffmpeg") and shutil.which("ffprobe"):
+        return
+    try:
+        import static_ffmpeg
+
+        static_ffmpeg.add_paths()
+    except Exception:
+        pass
+
+
+_ensure_ffmpeg_on_path()
+
+
+def has_ffmpeg() -> bool:
+    """Return True if both ffmpeg and ffprobe are available on PATH."""
+    return bool(shutil.which("ffmpeg") and shutil.which("ffprobe"))
 
 # A 1x1 transparent PNG, base64-encoded, reused by image-generation mocks.
 TEST_IMAGE_B64 = (

--- a/tests/test_image_ops.py
+++ b/tests/test_image_ops.py
@@ -1,0 +1,186 @@
+"""Tests for frame_interpolator and image_utils using real cv2/numpy/PIL.
+
+These exercise the stub frame interpolation (cv2/numpy blending) and the
+PIL-based text overlay helper with tiny, real, on-disk images.
+"""
+
+import cv2  # type: ignore
+import numpy as np
+from PIL import Image
+
+from youtube_shorts_gen.utils.frame_interpolator import interpolate_between
+from youtube_shorts_gen.utils.image_utils import overlay_text_on_images
+
+
+def _make_image(path, color, size=(16, 16)):
+    """Write a tiny solid-color BGR image to *path* via cv2."""
+    height, width = size
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    arr[:, :] = color
+    assert cv2.imwrite(str(path), arr)
+    return path
+
+
+# --------------------------------------------------------------------------
+# interpolate_between
+# --------------------------------------------------------------------------
+
+
+def test_interpolate_returns_n_readable_frames(tmp_path):
+    """Happy path: returns num_inter_frames real, readable image files."""
+    img1 = _make_image(tmp_path / "a.png", (0, 0, 0))
+    img2 = _make_image(tmp_path / "b.png", (255, 255, 255))
+    out_dir = tmp_path / "out"
+
+    outputs = interpolate_between(img1, img2, num_inter_frames=4, output_dir=out_dir)
+
+    assert len(outputs) == 4
+    for path in outputs:
+        assert path.startswith(str(out_dir))
+        frame = cv2.imread(path)
+        assert frame is not None
+        assert frame.shape == (16, 16, 3)
+    # Frames should be ordered/distinct: blending a black->white pair must
+    # produce monotonically increasing brightness.
+    means = []
+    for p in outputs:
+        frame = cv2.imread(p)
+        assert frame is not None
+        means.append(float(frame.mean()))
+    assert means == sorted(means)
+    assert means[0] < means[-1]
+
+
+def test_interpolate_single_frame_edge_case(tmp_path):
+    """Edge case: num_inter_frames=1 yields exactly one mid blend frame."""
+    img1 = _make_image(tmp_path / "a.png", (0, 0, 0))
+    img2 = _make_image(tmp_path / "b.png", (200, 200, 200))
+    out_dir = tmp_path / "single"
+
+    outputs = interpolate_between(img1, img2, num_inter_frames=1, output_dir=out_dir)
+
+    assert len(outputs) == 1
+    frame = cv2.imread(outputs[0])
+    assert frame is not None
+    # alpha = 1/(1+1) = 0.5 -> roughly half of 200.
+    assert 90 <= float(frame.mean()) <= 110
+
+
+def test_interpolate_resizes_mismatched_images(tmp_path):
+    """Mismatched sizes are resized to the first image's shape."""
+    img1 = _make_image(tmp_path / "a.png", (10, 20, 30), size=(16, 16))
+    img2 = _make_image(tmp_path / "b.png", (40, 50, 60), size=(32, 8))
+    out_dir = tmp_path / "resized"
+
+    outputs = interpolate_between(img1, img2, num_inter_frames=2, output_dir=out_dir)
+
+    assert len(outputs) == 2
+    for path in outputs:
+        frame = cv2.imread(path)
+        assert frame is not None
+        assert frame.shape == (16, 16, 3)
+
+
+def test_interpolate_defaults_output_dir_to_img1_dir(tmp_path):
+    """When output_dir is None, frames land next to the first image."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    img1 = _make_image(src_dir / "a.png", (0, 0, 0))
+    img2 = _make_image(src_dir / "b.png", (255, 255, 255))
+
+    outputs = interpolate_between(img1, img2, num_inter_frames=2)
+
+    assert len(outputs) == 2
+    for path in outputs:
+        assert str(src_dir) in path
+
+
+def test_interpolate_non_positive_frames_returns_empty(tmp_path):
+    """num_inter_frames <= 0 short-circuits to an empty list."""
+    img1 = _make_image(tmp_path / "a.png", (0, 0, 0))
+    img2 = _make_image(tmp_path / "b.png", (255, 255, 255))
+
+    assert interpolate_between(img1, img2, num_inter_frames=0) == []
+    assert interpolate_between(img1, img2, num_inter_frames=-3) == []
+
+
+def test_interpolate_unreadable_image_returns_empty(tmp_path):
+    """A missing/unreadable source image yields an empty list."""
+    img1 = _make_image(tmp_path / "a.png", (0, 0, 0))
+    missing = tmp_path / "does_not_exist.png"
+    out_dir = tmp_path / "out"
+
+    outputs = interpolate_between(img1, missing, num_inter_frames=3, output_dir=out_dir)
+
+    assert outputs == []
+
+
+# --------------------------------------------------------------------------
+# overlay_text_on_images
+# --------------------------------------------------------------------------
+
+
+def _make_pil_image(path, size=(64, 64), color=(10, 20, 30)):
+    """Write a tiny solid RGB image to *path* via PIL."""
+    Image.new("RGB", size, color).save(path)
+    return path
+
+
+def test_overlay_returns_one_output_per_input(tmp_path):
+    """Happy path: one saved output per input, all readable RGB images."""
+    paths = [
+        str(_make_pil_image(tmp_path / "one.png")),
+        str(_make_pil_image(tmp_path / "two.png")),
+    ]
+    texts = ["HELLO", "WORLD"]
+    out_dir = tmp_path / "overlaid"
+
+    results = overlay_text_on_images(paths, texts, out_dir)
+
+    assert len(results) == len(paths)
+    for original, result in zip(paths, results, strict=True):
+        assert result != original
+        assert result.startswith(str(out_dir))
+        with Image.open(result) as im:
+            assert im.mode == "RGB"
+            assert im.size == (64, 64)
+
+
+def test_overlay_changes_pixels(tmp_path):
+    """Overlaid text actually modifies pixels vs the source image."""
+    src = _make_pil_image(tmp_path / "src.png", color=(0, 0, 0))
+    out_dir = tmp_path / "out"
+
+    results = overlay_text_on_images([str(src)], ["TEXT"], out_dir)
+
+    assert len(results) == 1
+    with Image.open(src) as before, Image.open(results[0]) as after:
+        assert list(before.getdata()) != list(after.convert("RGB").getdata())
+
+
+def test_overlay_mismatched_lengths_uses_shortest(tmp_path):
+    """zip(strict=False) means extra images without text are skipped."""
+    paths = [
+        str(_make_pil_image(tmp_path / "a.png")),
+        str(_make_pil_image(tmp_path / "b.png")),
+    ]
+    out_dir = tmp_path / "out"
+
+    results = overlay_text_on_images(paths, ["only-one"], out_dir)
+
+    assert len(results) == 1
+    assert results[0].startswith(str(out_dir))
+
+
+def test_overlay_unreadable_image_falls_back_to_original(tmp_path):
+    """A bad image path is caught and the original path is returned."""
+    good = str(_make_pil_image(tmp_path / "good.png"))
+    bad = str(tmp_path / "missing.png")
+    out_dir = tmp_path / "out"
+
+    results = overlay_text_on_images([good, bad], ["a", "b"], out_dir)
+
+    assert len(results) == 2
+    assert results[0].startswith(str(out_dir))
+    # Failed entry falls back to the original input path unchanged.
+    assert results[1] == bad

--- a/tests/test_openai_image.py
+++ b/tests/test_openai_image.py
@@ -1,0 +1,238 @@
+"""Tests for youtube_shorts_gen.utils.openai_image.
+
+Covers the cache MISS path (writes file, returns path, calls the client), the
+empty-response path (returns ""), a forced cache HIT (reuses bytes without
+calling the client), and generate_sequential_images alignment / failure paths.
+
+All file I/O uses tmp_path and the module-level on-disk cache is isolated by
+monkeypatching _CACHE_INDEX and _CACHE_INDEX_FILE to fresh, temporary values.
+"""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+
+from youtube_shorts_gen.utils import openai_image
+
+# A valid 1x1 transparent PNG encoded as base64.
+PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z"
+    "8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_cache(monkeypatch, tmp_path):
+    """Give every test a fresh, on-disk cache index in a temp location."""
+    monkeypatch.setattr(openai_image, "_CACHE_INDEX", {})
+    monkeypatch.setattr(
+        openai_image, "_CACHE_INDEX_FILE", tmp_path / "index.json"
+    )
+
+
+def _make_client(b64=PNG_B64, empty=False):
+    """Build a MagicMock OpenAI client for images.generate."""
+    client = MagicMock()
+    if empty:
+        client.images.generate.return_value.data = []
+    else:
+        datum = MagicMock()
+        datum.b64_json = b64
+        client.images.generate.return_value.data = [datum]
+    return client
+
+
+def test_generate_image_cache_miss_writes_file(tmp_path):
+    """A cache miss writes the decoded bytes and returns the output path."""
+    client = _make_client()
+    out = tmp_path / "img.png"
+
+    result = openai_image.generate_image(client, "a prompt", out)
+
+    assert result == str(out)
+    assert out.exists()
+    assert out.read_bytes() == base64.b64decode(PNG_B64)
+    client.images.generate.assert_called_once()
+
+
+def test_generate_image_populates_cache_index(tmp_path):
+    """A successful generation records the path in the cache index + file."""
+    client = _make_client()
+    out = tmp_path / "img.png"
+
+    openai_image.generate_image(client, "another prompt", out)
+
+    assert str(out) in openai_image._CACHE_INDEX.values()
+    assert openai_image._CACHE_INDEX_FILE.exists()
+
+
+def test_generate_image_empty_response_returns_empty(tmp_path):
+    """An empty data list yields "" and writes nothing."""
+    client = _make_client(empty=True)
+    out = tmp_path / "img.png"
+
+    result = openai_image.generate_image(client, "prompt", out)
+
+    assert result == ""
+    assert not out.exists()
+
+
+def test_generate_image_blank_b64_returns_empty(tmp_path):
+    """A datum with falsy b64_json yields "" (treated as empty)."""
+    client = _make_client(b64="")
+    out = tmp_path / "img.png"
+
+    result = openai_image.generate_image(client, "prompt", out)
+
+    assert result == ""
+    assert not out.exists()
+
+
+def test_generate_image_cache_hit_skips_client(tmp_path, monkeypatch):
+    """A forced cache hit reuses bytes without calling images.generate."""
+    cached = tmp_path / "cached.png"
+    cached_bytes = base64.b64decode(PNG_B64)
+    cached.write_bytes(cached_bytes)
+
+    monkeypatch.setattr(
+        openai_image, "_get_cached_path", lambda key: cached
+    )
+
+    client = _make_client()
+    out = tmp_path / "out.png"
+    result = openai_image.generate_image(client, "prompt", out)
+
+    assert result == str(out)
+    assert out.read_bytes() == cached_bytes
+    client.images.generate.assert_not_called()
+
+
+def test_generate_image_error_path_returns_empty(tmp_path):
+    """An OSError during generation is caught and "" is returned."""
+    client = MagicMock()
+    client.images.generate.side_effect = OSError("disk full")
+    out = tmp_path / "img.png"
+
+    result = openai_image.generate_image(client, "prompt", out)
+
+    assert result == ""
+    assert not out.exists()
+
+
+def test_generate_image_unexpected_error_returns_empty(tmp_path):
+    """A non-(OSError, ValueError) exception is also swallowed -> ""."""
+    client = MagicMock()
+    client.images.generate.side_effect = RuntimeError("boom")
+    out = tmp_path / "img.png"
+
+    result = openai_image.generate_image(client, "prompt", out)
+
+    assert result == ""
+    assert not out.exists()
+
+
+def test_generate_sequential_images_happy_path(tmp_path):
+    """Each prompt produces an aligned output path."""
+    client = _make_client()
+    prompts = ["p1", "p2"]
+    outs = [tmp_path / "a.png", tmp_path / "b.png"]
+
+    results = openai_image.generate_sequential_images(client, prompts, outs)
+
+    assert results == [str(outs[0]), str(outs[1])]
+    assert all(p.exists() for p in outs)
+    assert client.images.generate.call_count == 2
+
+
+def test_generate_sequential_images_mismatched_lengths(tmp_path):
+    """Length mismatch returns "" entries sized to output_paths."""
+    client = _make_client()
+    outs = [tmp_path / "a.png", tmp_path / "b.png", tmp_path / "c.png"]
+
+    results = openai_image.generate_sequential_images(client, ["only"], outs)
+
+    assert results == ["", "", ""]
+    client.images.generate.assert_not_called()
+
+
+def test_generate_sequential_images_empty_prompts(tmp_path):
+    """Empty prompts returns a list of "" matching output_paths length."""
+    client = _make_client()
+    outs = [tmp_path / "a.png"]
+
+    results = openai_image.generate_sequential_images(client, [], outs)
+
+    assert results == [""]
+    client.images.generate.assert_not_called()
+
+
+def test_generate_sequential_images_partial_failure(tmp_path):
+    """A per-item failure yields "" in that position while others succeed."""
+    client = MagicMock()
+    good = MagicMock()
+    good.b64_json = PNG_B64
+    ok_resp = MagicMock()
+    ok_resp.data = [good]
+    client.images.generate.side_effect = [ok_resp, OSError("fail")]
+
+    prompts = ["p1", "p2"]
+    outs = [tmp_path / "a.png", tmp_path / "b.png"]
+
+    results = openai_image.generate_sequential_images(client, prompts, outs)
+
+    assert results == [str(outs[0]), ""]
+    assert outs[0].exists()
+    assert not outs[1].exists()
+
+
+def test_cache_key_is_stable_and_prompt_sensitive():
+    """_make_cache_key is deterministic and varies with the prompt."""
+    k1 = openai_image._make_cache_key("p", "1024x1024", "medium", "m")
+    k2 = openai_image._make_cache_key("p", "1024x1024", "medium", "m")
+    k3 = openai_image._make_cache_key("other", "1024x1024", "medium", "m")
+
+    assert k1 == k2
+    assert k1 != k3
+
+
+def test_get_cached_path_missing_file_returns_none(tmp_path, monkeypatch):
+    """_get_cached_path returns None when the recorded path is gone."""
+    monkeypatch.setattr(
+        openai_image,
+        "_CACHE_INDEX",
+        {"key": str(tmp_path / "nonexistent.png")},
+    )
+
+    assert openai_image._get_cached_path("key") is None
+
+
+def test_store_cache_persists_index(tmp_path, monkeypatch):
+    """_store_cache writes the index file with the new entry."""
+    index_file = tmp_path / "index.json"
+    monkeypatch.setattr(openai_image, "_CACHE_INDEX_FILE", index_file)
+    monkeypatch.setattr(openai_image, "_CACHE_INDEX", {})
+
+    img = tmp_path / "img.png"
+    openai_image._store_cache("k", img)
+
+    assert index_file.exists()
+    assert str(img) in index_file.read_text()
+    assert openai_image._CACHE_INDEX["k"] == str(img)
+
+
+def test_full_cache_roundtrip_second_call_reuses(tmp_path):
+    """First call generates; an aligned second call reuses without the API."""
+    client = _make_client()
+    out1 = tmp_path / "first.png"
+    out2 = tmp_path / "second.png"
+
+    first = openai_image.generate_image(client, "same prompt", out1)
+    assert first == str(out1)
+    assert client.images.generate.call_count == 1
+
+    # Same prompt -> cache hit; client should not be called again.
+    second = openai_image.generate_image(client, "same prompt", out2)
+    assert second == str(out2)
+    assert out2.read_bytes() == out1.read_bytes()
+    assert client.images.generate.call_count == 1

--- a/tests/test_runway.py
+++ b/tests/test_runway.py
@@ -1,0 +1,274 @@
+"""Unit tests for youtube_shorts_gen.media.runway.VideoGenerator.
+
+All RunwayML SDK calls, HTTP requests, and sleeps are mocked so the tests are
+fully hermetic and fast. File I/O is confined to pytest's tmp_path.
+"""
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from youtube_shorts_gen.media.runway import VideoGenerator
+
+_MOD = "youtube_shorts_gen.media.runway"
+
+# A 1x1 transparent PNG, base64-encoded.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmM"
+    "IQAAAABJRU5ErkJggg=="
+)
+
+
+def _write_png(path):
+    """Write a tiny real PNG to *path* and return the path as a string."""
+    path.write_bytes(base64.b64decode(_PNG_B64))
+    return str(path)
+
+
+def _make_generator(run_dir):
+    """Build a VideoGenerator with a mocked RunwayML client.
+
+    Returns ``(generator, mock_client)`` where ``mock_client`` is the MagicMock
+    standing in for the RunwayML SDK client, so tests configure it directly.
+    """
+    with (
+        patch(f"{_MOD}.RUNWAY_API_KEY", "test-key"),
+        patch(f"{_MOD}.RunwayML") as mock_runway,
+    ):
+        gen = VideoGenerator(str(run_dir))
+    mock_client = mock_runway.return_value
+    assert gen.client is mock_client
+    return gen, mock_client
+
+
+def test_init_requires_api_key(tmp_path):
+    """__init__ raises ValueError when RUNWAY_API_KEY is empty."""
+    with (
+        patch(f"{_MOD}.RUNWAY_API_KEY", ""),
+        patch(f"{_MOD}.RunwayML"),
+        pytest.raises(ValueError, match="RUNWAY_API_KEY"),
+    ):
+        VideoGenerator(str(tmp_path))
+
+
+def test_create_runway_prompt_non_empty_and_saved(tmp_path):
+    """_create_runway_prompt builds a non-empty string and saves it to disk."""
+    gen, _ = _make_generator(tmp_path)
+
+    prompt = gen._create_runway_prompt("A brave knight rescues a dragon today")
+
+    assert isinstance(prompt, str)
+    assert prompt.strip() != ""
+    # Template fragments must be present.
+    assert "realistic details" in prompt
+    assert "cinematic lighting" in prompt
+    saved = tmp_path / "runway_prompt.txt"
+    assert saved.exists()
+    assert saved.read_text(encoding="utf-8") == prompt
+
+
+def test_create_runway_prompt_empty_story_uses_default_subject(tmp_path):
+    """An empty story still yields a usable prompt (default subject path)."""
+    gen, _ = _make_generator(tmp_path)
+
+    prompt = gen._create_runway_prompt("")
+
+    assert prompt.strip() != ""
+    assert (tmp_path / "runway_prompt.txt").exists()
+
+
+def test_image_to_data_uri_png(tmp_path):
+    """_image_to_data_uri returns a base64 PNG data URI for a real file."""
+    gen, _ = _make_generator(tmp_path)
+    image_path = _write_png(tmp_path / "frame.png")
+
+    uri = gen._image_to_data_uri(image_path)
+
+    assert uri.startswith("data:image/png;base64,")
+    encoded = uri.split(",", 1)[1]
+    # Round-trips back to the original PNG bytes.
+    assert base64.b64decode(encoded) == base64.b64decode(_PNG_B64)
+
+
+def test_image_to_data_uri_jpg_mime(tmp_path):
+    """A .jpg extension maps to the image/jpeg MIME type."""
+    gen, _ = _make_generator(tmp_path)
+    image_path = tmp_path / "frame.jpg"
+    image_path.write_bytes(base64.b64decode(_PNG_B64))
+
+    uri = gen._image_to_data_uri(str(image_path))
+
+    assert uri.startswith("data:image/jpeg;base64,")
+
+
+def test_generate_missing_image_raises(tmp_path):
+    """generate() raises FileNotFoundError when the image path is absent."""
+    gen, _ = _make_generator(tmp_path)
+    missing = tmp_path / "does_not_exist.png"
+
+    with pytest.raises(FileNotFoundError, match="Image file not found"):
+        gen.generate(image_path=str(missing), prompt_text="hello world")
+
+
+def test_generate_happy_path_returns_video_path(tmp_path):
+    """Full happy path: create -> poll SUCCEEDED -> download -> return path."""
+    gen, client = _make_generator(tmp_path)
+    image_path = _write_png(tmp_path / "story_image.png")
+
+    client.image_to_video.create.return_value = MagicMock(id="task-123")
+
+    succeeded = MagicMock()
+    succeeded.status = "SUCCEEDED"
+    succeeded.output = ["http://x/v.mp4"]
+    client.tasks.retrieve.return_value = succeeded
+
+    http_response = MagicMock()
+    http_response.status_code = 200
+    http_response.iter_content.return_value = [b"chunk1", b"chunk2"]
+
+    with (
+        patch(f"{_MOD}.time.sleep"),
+        patch(f"{_MOD}.requests.get", return_value=http_response) as mock_get,
+    ):
+        result = gen.generate(
+            image_path=image_path, prompt_text="a serene mountain river"
+        )
+
+    # The create call carried the data URI and the generated prompt.
+    create_kwargs = client.image_to_video.create.call_args.kwargs
+    assert create_kwargs["prompt_image"].startswith("data:image/png;base64,")
+    assert create_kwargs["prompt_text"].strip() != ""
+
+    assert result != ""
+    assert result.endswith(".mp4")
+    out_path = tmp_path / "videos" / f"runway_video_{gen.current_video_id}.mp4"
+    assert str(out_path) == result
+    assert out_path.exists()
+    assert out_path.read_bytes() == b"chunk1chunk2"
+    mock_get.assert_called_once()
+    assert mock_get.call_args.args[0] == "http://x/v.mp4"
+
+
+def test_generate_uses_default_image_and_prompt_files(tmp_path):
+    """With no args, generate() reads story_image.png and the prompt file."""
+    gen, client = _make_generator(tmp_path)
+    _write_png(tmp_path / "story_image.png")
+    (tmp_path / "story_prompt.txt").write_text(
+        "A quiet forest at dawn", encoding="utf-8"
+    )
+
+    client.image_to_video.create.return_value = MagicMock(id="t1")
+    ok = MagicMock()
+    ok.status = "SUCCEEDED"
+    ok.output = ["http://x/v.mp4"]
+    client.tasks.retrieve.return_value = ok
+
+    http_response = MagicMock()
+    http_response.status_code = 200
+    http_response.iter_content.return_value = [b"data"]
+
+    with (
+        patch(f"{_MOD}.time.sleep"),
+        patch(f"{_MOD}.requests.get", return_value=http_response),
+    ):
+        result = gen.generate()
+
+    assert result.endswith(".mp4")
+    assert (tmp_path / "videos").is_dir()
+
+
+def test_generate_missing_prompt_file_raises(tmp_path):
+    """generate() raises FileNotFoundError when the prompt file is missing."""
+    gen, _ = _make_generator(tmp_path)
+    image_path = _write_png(tmp_path / "img.png")
+
+    with pytest.raises(FileNotFoundError, match="Prompt file not found"):
+        gen.generate(image_path=image_path)
+
+
+def test_generate_no_task_id_raises_runtime_error(tmp_path):
+    """A create response without an id triggers a RuntimeError."""
+    gen, client = _make_generator(tmp_path)
+    image_path = _write_png(tmp_path / "img.png")
+
+    client.image_to_video.create.return_value = MagicMock(id=None)
+
+    with (
+        patch(f"{_MOD}.time.sleep"),
+        pytest.raises(RuntimeError, match="did not return a task id"),
+    ):
+        gen.generate(image_path=image_path, prompt_text="some prompt text")
+
+
+def test_generate_failed_status_raises_runtime_error(tmp_path):
+    """A FAILED task status raises a RuntimeError."""
+    gen, client = _make_generator(tmp_path)
+    image_path = _write_png(tmp_path / "img.png")
+
+    client.image_to_video.create.return_value = MagicMock(id="t9")
+    failed = MagicMock()
+    failed.status = "FAILED"
+    client.tasks.retrieve.return_value = failed
+
+    with (
+        patch(f"{_MOD}.time.sleep"),
+        pytest.raises(RuntimeError, match="Video generation failed"),
+    ):
+        gen.generate(image_path=image_path, prompt_text="prompt body here")
+
+
+def test_generate_polling_timeout_returns_empty(tmp_path):
+    """Status never reaching a terminal state returns "" after max attempts."""
+    gen, client = _make_generator(tmp_path)
+    image_path = _write_png(tmp_path / "img.png")
+
+    client.image_to_video.create.return_value = MagicMock(id="t-timeout")
+    pending = MagicMock()
+    pending.status = "RUNNING"
+    client.tasks.retrieve.return_value = pending
+
+    with (
+        patch(f"{_MOD}.RUNWAY_MAX_POLL_ATTEMPTS", 3),
+        patch(f"{_MOD}.time.sleep") as mock_sleep,
+        patch(f"{_MOD}.requests.get") as mock_get,
+    ):
+        result = gen.generate(image_path=image_path, prompt_text="loop forever")
+
+    assert result == ""
+    assert client.tasks.retrieve.call_count == 3
+    assert mock_sleep.call_count == 3
+    mock_get.assert_not_called()
+
+
+def test_generate_succeeded_but_no_output_raises(tmp_path):
+    """SUCCEEDED with an empty output list raises a RuntimeError."""
+    gen, client = _make_generator(tmp_path)
+    image_path = _write_png(tmp_path / "img.png")
+
+    client.image_to_video.create.return_value = MagicMock(id="t0")
+    no_output = MagicMock()
+    no_output.status = "SUCCEEDED"
+    no_output.output = []
+    client.tasks.retrieve.return_value = no_output
+
+    with (
+        patch(f"{_MOD}.time.sleep"),
+        pytest.raises(RuntimeError, match="returned no output"),
+    ):
+        gen.generate(image_path=image_path, prompt_text="prompt content")
+
+
+def test_download_video_non_200_raises_connection_error(tmp_path):
+    """_download_video raises ConnectionError on a non-200 response."""
+    gen, _ = _make_generator(tmp_path)
+    gen.current_video_id = 4242
+
+    bad_response = MagicMock()
+    bad_response.status_code = 404
+
+    with (
+        patch(f"{_MOD}.requests.get", return_value=bad_response),
+        pytest.raises(ConnectionError, match="status code = 404"),
+    ):
+        gen._download_video("http://x/missing.mp4")

--- a/tests/test_text_processor.py
+++ b/tests/test_text_processor.py
@@ -1,0 +1,156 @@
+"""Tests for youtube_shorts_gen.media.text_processor.TextProcessor."""
+
+from unittest.mock import MagicMock
+
+from openai import OpenAIError
+
+from youtube_shorts_gen.media.text_processor import TextProcessor
+from youtube_shorts_gen.utils.config import (
+    MAX_PARAGRAPHS_FOR_SHORTS,
+    SUMMARIZE_THRESHOLD_CHARS,
+)
+
+
+def _make_processor(run_dir, client=None):
+    """Build a TextProcessor with a mock OpenAI client."""
+    return TextProcessor(str(run_dir), client or MagicMock())
+
+
+def _chat_response(content):
+    """Build a mock OpenAI chat completion response with given content."""
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    return response
+
+
+def test_split_multi_paragraph_story_into_segments(tmp_path):
+    """A multi-paragraph story is split into stripped paragraph segments."""
+    processor = _make_processor(tmp_path)
+    text = "First paragraph.\n\n  Second paragraph.  \n\nThird paragraph."
+
+    segments = processor.get_content_segments(text)
+
+    assert segments == [
+        "First paragraph.",
+        "Second paragraph.",
+        "Third paragraph.",
+    ]
+
+
+def test_paragraphs_capped_at_max(tmp_path):
+    """More than MAX_PARAGRAPHS_FOR_SHORTS paragraphs are truncated to the cap."""
+    processor = _make_processor(tmp_path)
+    num_paragraphs = MAX_PARAGRAPHS_FOR_SHORTS + 5
+    # Keep each paragraph short so summarization never triggers.
+    paragraphs = [f"Paragraph number {i}." for i in range(num_paragraphs)]
+    text = "\n\n".join(paragraphs)
+
+    segments = processor.get_content_segments(text)
+
+    assert len(segments) == MAX_PARAGRAPHS_FOR_SHORTS
+    assert segments == paragraphs[:MAX_PARAGRAPHS_FOR_SHORTS]
+
+
+def test_long_paragraph_is_summarized_via_client(tmp_path):
+    """A paragraph over the threshold is summarized using the client's output."""
+    client = MagicMock()
+    summary = "A short summary of the long paragraph."
+    client.chat.completions.create.return_value = _chat_response(summary)
+    processor = _make_processor(tmp_path, client)
+
+    long_paragraph = "word " * (SUMMARIZE_THRESHOLD_CHARS + 50)
+    assert len(long_paragraph) > SUMMARIZE_THRESHOLD_CHARS
+
+    segments = processor.get_content_segments(long_paragraph)
+
+    client.chat.completions.create.assert_called_once()
+    assert segments == [summary]
+
+
+def test_summarize_failure_falls_back_to_truncation(tmp_path):
+    """If the client raises, the paragraph is truncated to 500 chars, no raise."""
+    client = MagicMock()
+    client.chat.completions.create.side_effect = OpenAIError("boom")
+    processor = _make_processor(tmp_path, client)
+
+    long_paragraph = "x" * (SUMMARIZE_THRESHOLD_CHARS + 600)
+    assert len(long_paragraph) > 500
+
+    segments = processor.get_content_segments(long_paragraph)
+
+    client.chat.completions.create.assert_called_once()
+    assert segments == [long_paragraph[:500]]
+    assert len(segments[0]) == 500
+
+
+def test_short_paragraph_is_not_summarized(tmp_path):
+    """Paragraphs at or below the threshold are returned untouched."""
+    client = MagicMock()
+    processor = _make_processor(tmp_path, client)
+    # Two short paragraphs so the single-large-segment fallback is not hit.
+    text = "A short first line.\n\nA short second line."
+
+    segments = processor.get_content_segments(text)
+
+    client.chat.completions.create.assert_not_called()
+    assert segments == ["A short first line.", "A short second line."]
+
+
+def test_summarize_disabled_returns_raw_segments(tmp_path):
+    """When summarization is disabled the long paragraph is returned as-is."""
+    client = MagicMock()
+    processor = _make_processor(tmp_path, client)
+    long_paragraph = "y" * (SUMMARIZE_THRESHOLD_CHARS + 100)
+
+    segments = processor.get_content_segments(
+        long_paragraph, summarize_long_paragraphs=False
+    )
+
+    client.chat.completions.create.assert_not_called()
+    assert segments == [long_paragraph]
+
+
+def test_mapping_file_sentences_take_priority(tmp_path):
+    """Sentences from the mapping file are used and short-circuit splitting."""
+    client = MagicMock()
+    mapping = tmp_path / "sentence_image_mapping.txt"
+    mapping.write_text(
+        "Sentence 1: First mapped sentence.\n"
+        "Image: /tmp/img1.png\n\n"
+        "Sentence 2: Second mapped sentence.\n"
+        "Image: /tmp/img2.png\n",
+        encoding="utf-8",
+    )
+    processor = _make_processor(tmp_path, client)
+
+    segments = processor.get_content_segments("ignored text here")
+
+    assert segments == ["First mapped sentence.", "Second mapped sentence."]
+    client.chat.completions.create.assert_not_called()
+
+
+def test_single_large_paragraph_falls_back_to_sentences(tmp_path):
+    """One large paragraph with multiple sentences is re-split by sentence."""
+    client = MagicMock()
+    processor = _make_processor(tmp_path, client)
+    sentence = "This is a fairly wordy sentence about dragons and knights. "
+    text = sentence * 12  # one paragraph, >500 chars, many sentences
+
+    segments = processor.get_content_segments(
+        text, summarize_long_paragraphs=False
+    )
+
+    assert len(segments) > 1
+    assert all(s.endswith(".") for s in segments)
+
+
+def test_empty_text_returns_empty_list(tmp_path):
+    """Whitespace-only input yields no segments without errors."""
+    client = MagicMock()
+    processor = _make_processor(tmp_path, client)
+
+    segments = processor.get_content_segments("   \n\n   ")
+
+    assert segments == []
+    client.chat.completions.create.assert_not_called()

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,0 +1,164 @@
+"""Tests for the TTSGenerator and ParagraphTTS text-to-speech modules."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from youtube_shorts_gen.media.paragraph_tts import ParagraphTTS
+from youtube_shorts_gen.media.tts_generator import TTSGenerator
+from youtube_shorts_gen.utils.config import (
+    STORY_AUDIO_FILENAME,
+    STORY_PROMPT_FILENAME,
+)
+
+
+def _make_client(chunks):
+    """Return a MagicMock ElevenLabs client whose convert yields chunks."""
+    client = MagicMock()
+    client.text_to_speech.convert.return_value = iter(chunks)
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# TTSGenerator
+# --------------------------------------------------------------------------- #
+def test_generate_from_text_writes_mp3(tmp_path, monkeypatch):
+    """generate_from_text writes joined byte chunks and returns the path."""
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "k")
+    client = _make_client([b"aa", b"bb"])
+
+    with patch(
+        "youtube_shorts_gen.media.tts_generator.ElevenLabs",
+        return_value=client,
+    ) as mock_eleven:
+        gen = TTSGenerator(str(tmp_path))
+        result = gen.generate_from_text("hello world")
+
+    expected = tmp_path / STORY_AUDIO_FILENAME
+    assert result == str(expected)
+    assert expected.exists()
+    assert expected.read_bytes() == b"aabb"
+    mock_eleven.assert_called_once_with(api_key="k")
+    # The text we passed is forwarded to the API.
+    _, kwargs = client.text_to_speech.convert.call_args
+    assert kwargs["text"] == "hello world"
+
+
+def test_generate_from_text_missing_api_key_raises(tmp_path, monkeypatch):
+    """Missing ELEVENLABS_API_KEY raises OSError and writes no file."""
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+
+    with patch("youtube_shorts_gen.media.tts_generator.ElevenLabs") as mock_eleven:
+        gen = TTSGenerator(str(tmp_path))
+        with pytest.raises(OSError, match="ELEVENLABS_API_KEY"):
+            gen.generate_from_text("hello")
+
+    mock_eleven.assert_not_called()
+    assert not (tmp_path / STORY_AUDIO_FILENAME).exists()
+
+
+def test_generate_from_file_missing_story_raises(tmp_path, monkeypatch):
+    """generate_from_file raises FileNotFoundError when the story is absent."""
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "k")
+
+    with patch("youtube_shorts_gen.media.tts_generator.ElevenLabs") as mock_eleven:
+        gen = TTSGenerator(str(tmp_path))
+        with pytest.raises(FileNotFoundError, match=STORY_PROMPT_FILENAME):
+            gen.generate_from_file()
+
+    mock_eleven.assert_not_called()
+
+
+def test_generate_from_file_reads_and_synthesizes(tmp_path, monkeypatch):
+    """generate_from_file reads the story file then synthesizes its text."""
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "k")
+    prompt = tmp_path / STORY_PROMPT_FILENAME
+    prompt.write_text("  once upon a time  ", encoding="utf-8")
+    client = _make_client([b"xx", b"yy"])
+
+    with patch(
+        "youtube_shorts_gen.media.tts_generator.ElevenLabs",
+        return_value=client,
+    ):
+        gen = TTSGenerator(str(tmp_path))
+        result = gen.generate_from_file()
+
+    expected = tmp_path / STORY_AUDIO_FILENAME
+    assert result == str(expected)
+    assert Path(result).read_bytes() == b"xxyy"
+    # The file content is stripped before being sent to the API.
+    _, kwargs = client.text_to_speech.convert.call_args
+    assert kwargs["text"] == "once upon a time"
+
+
+# --------------------------------------------------------------------------- #
+# ParagraphTTS
+# --------------------------------------------------------------------------- #
+def test_init_creates_audio_dir(tmp_path):
+    """Constructing ParagraphTTS creates the paragraph_audio directory."""
+    tts = ParagraphTTS(str(tmp_path))
+    assert tts.audio_dir == tmp_path / "paragraph_audio"
+    assert tts.audio_dir.is_dir()
+
+
+def test_generate_for_paragraphs_writes_all(tmp_path, monkeypatch):
+    """generate_for_paragraphs returns a path per paragraph with byte content."""
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "k")
+    client = _make_client([b"aa", b"bb"])
+    client.text_to_speech.convert.side_effect = lambda **_: iter([b"aa", b"bb"])
+
+    with patch(
+        "youtube_shorts_gen.media.paragraph_tts.ElevenLabs",
+        return_value=client,
+    ):
+        tts = ParagraphTTS(str(tmp_path))
+        paths = tts.generate_for_paragraphs(["first", "second"])
+
+    assert paths == [
+        str(tmp_path / "paragraph_audio" / "paragraph_1.mp3"),
+        str(tmp_path / "paragraph_audio" / "paragraph_2.mp3"),
+    ]
+    for path in paths:
+        assert Path(path).read_bytes() == b"aabb"
+
+
+def test_generate_for_paragraphs_skips_api_failure(tmp_path, monkeypatch, caplog):
+    """A paragraph whose API call raises is logged and excluded from results."""
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "k")
+    client = MagicMock()
+
+    def _convert(**_):
+        if client.text_to_speech.convert.call_count == 1:
+            return iter([b"ok"])
+        raise RuntimeError("boom")
+
+    client.text_to_speech.convert.side_effect = _convert
+
+    with (
+        patch(
+            "youtube_shorts_gen.media.paragraph_tts.ElevenLabs",
+            return_value=client,
+        ),
+        caplog.at_level("ERROR"),
+    ):
+        tts = ParagraphTTS(str(tmp_path))
+        paths = tts.generate_for_paragraphs(["good", "bad"])
+
+    # Only the successful paragraph is kept; the failed one is skipped.
+    assert paths == [str(tmp_path / "paragraph_audio" / "paragraph_1.mp3")]
+    assert Path(paths[0]).read_bytes() == b"ok"
+    assert not (tmp_path / "paragraph_audio" / "paragraph_2.mp3").exists()
+    assert "paragraph 2" in caplog.text
+
+
+def test_generate_for_paragraph_missing_api_key_returns_none(tmp_path, monkeypatch):
+    """generate_for_paragraph returns None when the API key is unset."""
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+
+    with patch("youtube_shorts_gen.media.paragraph_tts.ElevenLabs") as mock_eleven:
+        tts = ParagraphTTS(str(tmp_path))
+        result = tts.generate_for_paragraph("text", 0)
+
+    assert result is None
+    mock_eleven.assert_not_called()

--- a/tests/test_upload_history.py
+++ b/tests/test_upload_history.py
@@ -1,0 +1,156 @@
+"""Tests for youtube_shorts_gen.upload.upload_history.UploadHistory."""
+
+import json
+
+from youtube_shorts_gen.upload.upload_history import UploadHistory
+
+
+def test_init_creates_missing_file_with_empty_shape(tmp_path):
+    """A fresh history file is created with the empty {"uploads": []} shape."""
+    history_file = tmp_path / "h.json"
+    assert not history_file.exists()
+
+    history = UploadHistory(history_file=str(history_file))
+
+    assert history_file.exists()
+    assert history.load_history() == {"uploads": []}
+
+
+def test_load_history_missing_file_returns_empty_shape(tmp_path):
+    """load_history returns the empty shape when no entries exist yet."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+
+    assert history.load_history() == {"uploads": []}
+
+
+def test_add_upload_then_is_duplicate_title(tmp_path):
+    """A title added to history is reported as a duplicate."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+
+    assert history.is_duplicate_title("My Title") is False
+
+    history.add_upload("My Title", "http://example.com/v", "Once upon a time")
+
+    assert history.is_duplicate_title("My Title") is True
+
+
+def test_is_duplicate_title_is_case_sensitive(tmp_path):
+    """Title matching is exact/case-sensitive, so casing differences are unique."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+    history.add_upload("My Title", "http://example.com/v", "story")
+
+    assert history.is_duplicate_title("My Title") is True
+    assert history.is_duplicate_title("my title") is False
+    assert history.is_duplicate_title("MY TITLE") is False
+
+
+def test_add_upload_persists_fields_and_truncates_long_story(tmp_path):
+    """add_upload writes title/url/date and truncates long story snippets."""
+    history_file = tmp_path / "h.json"
+    history = UploadHistory(history_file=str(history_file))
+
+    long_story = "x" * 250
+    history.add_upload("Title", "http://example.com/v", long_story)
+
+    data = json.loads(history_file.read_text(encoding="utf-8"))
+    assert len(data["uploads"]) == 1
+    entry = data["uploads"][0]
+    assert entry["title"] == "Title"
+    assert entry["url"] == "http://example.com/v"
+    assert entry["story_snippet"] == "x" * 100 + "..."
+    assert "upload_date" in entry
+
+
+def test_add_upload_keeps_short_story_untruncated(tmp_path):
+    """Short stories are stored verbatim with no ellipsis."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+
+    history.add_upload("T", "u", "short story")
+
+    entry = history.load_history()["uploads"][0]
+    assert entry["story_snippet"] == "short story"
+
+
+def test_save_load_round_trip(tmp_path):
+    """save_history then load_history returns the same structure."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+
+    payload = {
+        "uploads": [
+            {
+                "title": "A",
+                "url": "uA",
+                "story_snippet": "s",
+                "upload_date": "2026-01-01T00:00:00",
+            }
+        ]
+    }
+    history.save_history(payload)
+
+    assert history.load_history() == payload
+
+
+def test_get_recent_uploads_orders_newest_first(tmp_path):
+    """get_recent_uploads sorts by upload_date descending."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+    history.save_history(
+        {
+            "uploads": [
+                {"title": "old", "url": "u1", "upload_date": "2026-01-01T00:00:00"},
+                {"title": "new", "url": "u2", "upload_date": "2026-03-01T00:00:00"},
+                {"title": "mid", "url": "u3", "upload_date": "2026-02-01T00:00:00"},
+            ]
+        }
+    )
+
+    recent = history.get_recent_uploads()
+    titles = [u["title"] for u in recent]
+    assert titles == ["new", "mid", "old"]
+
+
+def test_get_recent_uploads_respects_limit(tmp_path):
+    """get_recent_uploads returns at most `limit` entries, newest first."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+    history.save_history(
+        {
+            "uploads": [
+                {"title": f"t{i}", "url": "u", "upload_date": f"2026-01-0{i}T00:00:00"}
+                for i in range(1, 6)
+            ]
+        }
+    )
+
+    recent = history.get_recent_uploads(limit=2)
+    assert len(recent) == 2
+    assert [u["title"] for u in recent] == ["t5", "t4"]
+
+
+def test_get_recent_uploads_empty_history(tmp_path):
+    """An empty history yields an empty recent-uploads list."""
+    history = UploadHistory(history_file=str(tmp_path / "h.json"))
+
+    assert history.get_recent_uploads() == []
+
+
+def test_load_history_corrupted_file_returns_empty_without_raising(tmp_path):
+    """A corrupted JSON file is recovered to the empty shape without raising."""
+    history_file = tmp_path / "h.json"
+    history = UploadHistory(history_file=str(history_file))
+
+    # Corrupt the file with non-JSON garbage.
+    history_file.write_text("{not valid json!!!", encoding="utf-8")
+
+    result = history.load_history()
+
+    assert result == {"uploads": []}
+    # The recovery also rewrote the file with the empty shape.
+    assert json.loads(history_file.read_text(encoding="utf-8")) == {"uploads": []}
+
+
+def test_is_duplicate_title_on_corrupted_file(tmp_path):
+    """is_duplicate_title degrades gracefully when the file is corrupted."""
+    history_file = tmp_path / "h.json"
+    history = UploadHistory(history_file=str(history_file))
+    history_file.write_text("garbage", encoding="utf-8")
+
+    assert history.is_duplicate_title("anything") is False

--- a/tests/test_upload_to_youtube.py
+++ b/tests/test_upload_to_youtube.py
@@ -1,0 +1,237 @@
+"""Tests for the YouTube uploader (no real Google API calls)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from youtube_shorts_gen.upload.upload_history import UploadHistory
+from youtube_shorts_gen.upload.upload_to_youtube import YouTubeUploader
+from youtube_shorts_gen.utils.config import (
+    FINAL_VIDEO_FILENAME,
+    STORY_PROMPT_FILENAME,
+    YOUTUBE_CATEGORY_ID,
+    YOUTUBE_DEFAULT_TAGS,
+    YOUTUBE_PRIVACY_STATUS,
+)
+
+_MODULE = "youtube_shorts_gen.upload.upload_to_youtube"
+
+
+def _make_uploader(run_dir, history_file, *, creds=None):
+    """Construct a YouTubeUploader with credentials and history mocked.
+
+    Patches ``_load_credentials`` to return ``creds`` (None by default) and
+    points ``UploadHistory`` at ``history_file`` so nothing touches the repo.
+    """
+    history = UploadHistory(history_file=str(history_file))
+    with (
+        patch.object(YouTubeUploader, "_load_credentials", return_value=creds),
+        patch(f"{_MODULE}.UploadHistory", return_value=history),
+        patch(f"{_MODULE}.build") as mock_build,
+    ):
+        uploader = YouTubeUploader(str(run_dir))
+    return uploader, mock_build
+
+
+def _write_story(run_dir, story):
+    (Path(run_dir) / STORY_PROMPT_FILENAME).write_text(story, encoding="utf-8")
+
+
+def _write_video(run_dir):
+    (Path(run_dir) / FINAL_VIDEO_FILENAME).write_bytes(b"\x00\x00fakevideo")
+
+
+# --------------------------------------------------------------------------- #
+# Constructor defaults
+# --------------------------------------------------------------------------- #
+def test_constructor_pulls_defaults_from_config(tmp_path):
+    uploader, mock_build = _make_uploader(tmp_path, tmp_path / "hist.json")
+
+    assert uploader.category_id == YOUTUBE_CATEGORY_ID
+    assert uploader.privacy_status == YOUTUBE_PRIVACY_STATUS
+    assert uploader.tags == YOUTUBE_DEFAULT_TAGS
+    assert uploader.run_dir == tmp_path
+    assert uploader.prompt_path == tmp_path / STORY_PROMPT_FILENAME
+    assert uploader.video_path == tmp_path / FINAL_VIDEO_FILENAME
+    # No credentials -> no youtube service is built.
+    assert uploader.youtube is None
+    mock_build.assert_not_called()
+
+
+def test_constructor_overrides_and_default_tags_fallback(tmp_path):
+    history = UploadHistory(history_file=str(tmp_path / "hist.json"))
+    with (
+        patch.object(YouTubeUploader, "_load_credentials", return_value=None),
+        patch(f"{_MODULE}.UploadHistory", return_value=history),
+        patch(f"{_MODULE}.build"),
+    ):
+        uploader = YouTubeUploader(
+            str(tmp_path),
+            category_id="27",
+            privacy_status="unlisted",
+            default_tags=None,
+        )
+
+    assert uploader.category_id == "27"
+    assert uploader.privacy_status == "unlisted"
+    # default_tags=None falls back to the config default list.
+    assert uploader.tags == YOUTUBE_DEFAULT_TAGS
+
+
+def test_constructor_uses_explicit_tags(tmp_path):
+    history = UploadHistory(history_file=str(tmp_path / "hist.json"))
+    with (
+        patch.object(YouTubeUploader, "_load_credentials", return_value=None),
+        patch(f"{_MODULE}.UploadHistory", return_value=history),
+        patch(f"{_MODULE}.build"),
+    ):
+        uploader = YouTubeUploader(str(tmp_path), default_tags=["only", "these"])
+
+    assert uploader.tags == ["only", "these"]
+
+
+def test_constructor_builds_service_when_creds_present(tmp_path):
+    history = UploadHistory(history_file=str(tmp_path / "hist.json"))
+    fake_creds = MagicMock()
+    fake_service = MagicMock()
+    with (
+        patch.object(
+            YouTubeUploader, "_load_credentials", return_value=fake_creds
+        ),
+        patch(f"{_MODULE}.UploadHistory", return_value=history),
+        patch(f"{_MODULE}.build", return_value=fake_service) as mock_build,
+    ):
+        uploader = YouTubeUploader(str(tmp_path))
+
+    assert uploader.youtube is fake_service
+    mock_build.assert_called_once_with(
+        "youtube", "v3", credentials=fake_creds
+    )
+
+
+# --------------------------------------------------------------------------- #
+# upload(): credential / file failure paths
+# --------------------------------------------------------------------------- #
+def test_upload_returns_none_without_credentials(tmp_path):
+    uploader, _ = _make_uploader(tmp_path, tmp_path / "hist.json")
+    _write_story(tmp_path, "line one\nMy Title")
+    _write_video(tmp_path)
+
+    # youtube is None because credentials could not be loaded.
+    assert uploader.upload() is None
+
+
+def test_upload_returns_none_when_video_missing(tmp_path):
+    history_file = tmp_path / "hist.json"
+    fake_creds = MagicMock()
+    uploader, _ = _make_uploader(tmp_path, history_file, creds=fake_creds)
+    # Provide a fake youtube service so we get past the creds check.
+    uploader.youtube = MagicMock()
+    _write_story(tmp_path, "line one\nMy Title")
+    # Note: no video file written.
+
+    assert uploader.upload() is None
+    uploader.youtube.videos.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# upload(): successful upload path
+# --------------------------------------------------------------------------- #
+def _drive_successful_upload(uploader, video_id="abc123"):
+    """Wire a fake youtube service whose execute() returns a video id."""
+    fake_youtube = MagicMock()
+    request = fake_youtube.videos.return_value.insert.return_value
+    request.execute.return_value = {"id": video_id}
+    uploader.youtube = fake_youtube
+    with patch(f"{_MODULE}.MediaFileUpload") as mock_media:
+        url = uploader.upload()
+    return url, fake_youtube, mock_media
+
+
+def test_upload_success_returns_url_and_records_history(tmp_path):
+    history_file = tmp_path / "hist.json"
+    uploader, _ = _make_uploader(
+        tmp_path, history_file, creds=MagicMock()
+    )
+    _write_story(tmp_path, "first line\nSecond Line Title")
+    _write_video(tmp_path)
+
+    url, fake_youtube, mock_media = _drive_successful_upload(uploader)
+
+    assert url == "https://www.youtube.com/watch?v=abc123"
+    mock_media.assert_called_once()
+    # Title comes from the second line of the story.
+    insert_kwargs = fake_youtube.videos.return_value.insert.call_args.kwargs
+    assert insert_kwargs["body"]["snippet"]["title"] == "Second Line Title"
+    assert insert_kwargs["part"] == "snippet,status"
+    assert insert_kwargs["body"]["status"]["privacyStatus"] == (
+        YOUTUBE_PRIVACY_STATUS
+    )
+
+    # History file updated with the new upload.
+    recorded = UploadHistory(history_file=str(history_file)).load_history()
+    titles = [u["title"] for u in recorded["uploads"]]
+    assert "Second Line Title" in titles
+    assert recorded["uploads"][0]["url"] == url
+
+
+def test_upload_title_falls_back_to_first_line(tmp_path):
+    history_file = tmp_path / "hist.json"
+    uploader, _ = _make_uploader(
+        tmp_path, history_file, creds=MagicMock()
+    )
+    # Only one line -> the first line is used as the title.
+    _write_story(tmp_path, "Only One Line")
+    _write_video(tmp_path)
+
+    url, fake_youtube, _ = _drive_successful_upload(uploader)
+
+    assert url == "https://www.youtube.com/watch?v=abc123"
+    insert_kwargs = fake_youtube.videos.return_value.insert.call_args.kwargs
+    assert insert_kwargs["body"]["snippet"]["title"] == "Only One Line"
+
+
+def test_upload_dedupes_duplicate_title(tmp_path):
+    history_file = tmp_path / "hist.json"
+    # Pre-seed history with the title we are about to upload.
+    seed = UploadHistory(history_file=str(history_file))
+    seed.add_upload("Second Line Title", "https://youtu.be/old", "old story")
+
+    uploader, _ = _make_uploader(
+        tmp_path, history_file, creds=MagicMock()
+    )
+    _write_story(tmp_path, "first line\nSecond Line Title")
+    _write_video(tmp_path)
+
+    url, fake_youtube, _ = _drive_successful_upload(uploader, video_id="dup99")
+
+    assert url == "https://www.youtube.com/watch?v=dup99"
+    insert_kwargs = fake_youtube.videos.return_value.insert.call_args.kwargs
+    sent_title = insert_kwargs["body"]["snippet"]["title"]
+    # The duplicate title is suffixed with a timestamp to make it unique.
+    assert sent_title.startswith("Second Line Title (")
+    assert sent_title != "Second Line Title"
+
+    recorded = UploadHistory(history_file=str(history_file)).load_history()
+    assert len(recorded["uploads"]) == 2
+
+
+def test_upload_returns_none_when_execute_raises(tmp_path):
+    history_file = tmp_path / "hist.json"
+    uploader, _ = _make_uploader(
+        tmp_path, history_file, creds=MagicMock()
+    )
+    _write_story(tmp_path, "first line\nSecond Line Title")
+    _write_video(tmp_path)
+
+    fake_youtube = MagicMock()
+    request = fake_youtube.videos.return_value.insert.return_value
+    request.execute.side_effect = RuntimeError("boom")
+    uploader.youtube = fake_youtube
+
+    with patch(f"{_MODULE}.MediaFileUpload"):
+        result = uploader.upload()
+
+    assert result is None
+    # Failed upload is not recorded in history.
+    recorded = UploadHistory(history_file=str(history_file)).load_history()
+    assert recorded["uploads"] == []

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -1,0 +1,166 @@
+"""Tests for story prompt generation, run-directory setup, and the
+OpenAI client accessor."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from youtube_shorts_gen.content.story_prompt_gen import generate_dynamic_prompt
+from youtube_shorts_gen.utils import openai_client, setup
+from youtube_shorts_gen.utils.config import (
+    ACTIONS,
+    ANIMALS,
+    BACKGROUNDS,
+    DANCES,
+    HUMANS,
+)
+
+_PROMPT_MOD = "youtube_shorts_gen.content.story_prompt_gen"
+_SETUP_MOD = "youtube_shorts_gen.utils.setup"
+_CLIENT_MOD = "youtube_shorts_gen.utils.openai_client"
+
+
+# --------------------------------------------------------------------------- #
+# generate_dynamic_prompt
+# --------------------------------------------------------------------------- #
+def test_generate_dynamic_prompt_returns_nonempty_str():
+    """Happy path: a non-empty string of stable type is returned."""
+    result = generate_dynamic_prompt()
+
+    assert isinstance(result, str)
+    assert result.strip()
+
+
+def test_generate_dynamic_prompt_includes_one_element_per_list():
+    """The rendered prompt embeds a chosen element from each config list."""
+    result = generate_dynamic_prompt()
+
+    assert any(animal in result for animal in ANIMALS)
+    assert any(human in result for human in HUMANS)
+    assert any(bg in result for bg in BACKGROUNDS)
+    assert any(dance in result for dance in DANCES)
+    assert any(action in result for action in ACTIONS)
+
+
+def test_generate_dynamic_prompt_uses_random_choices():
+    """random.choice drives selection; patching it fixes the output."""
+    with patch(
+        f"{_PROMPT_MOD}.random.choice",
+        side_effect=lambda seq: seq[0],
+    ) as mock_choice:
+        result = generate_dynamic_prompt()
+
+    assert mock_choice.call_count == 5
+    assert ANIMALS[0] in result
+    assert HUMANS[0] in result
+    assert BACKGROUNDS[0] in result
+    assert DANCES[0] in result
+    assert ACTIONS[0] in result
+
+
+def test_generate_dynamic_prompt_stable_type_across_calls():
+    """Type stays str across several independent invocations."""
+    results = [generate_dynamic_prompt() for _ in range(5)]
+
+    assert all(isinstance(r, str) and r for r in results)
+
+
+def test_generate_dynamic_prompt_propagates_choice_errors():
+    """Errors from random.choice (e.g. empty sequence) bubble up."""
+    with (
+        patch(f"{_PROMPT_MOD}.random.choice", side_effect=IndexError("empty")),
+        pytest.raises(IndexError),
+    ):
+        generate_dynamic_prompt()
+
+
+# --------------------------------------------------------------------------- #
+# setup_run_directory
+# --------------------------------------------------------------------------- #
+def test_setup_run_directory_creates_dir_under_base(tmp_path, monkeypatch):
+    """Happy path: a timestamped run dir is created under the base dir."""
+    monkeypatch.setattr(setup, "RUNS_BASE_DIR", str(tmp_path))
+
+    run_dir = setup.setup_run_directory()
+
+    assert isinstance(run_dir, Path)
+    assert run_dir.exists()
+    assert run_dir.is_dir()
+    assert run_dir.parent == tmp_path
+
+
+def test_setup_run_directory_uses_timestamp_name(tmp_path, monkeypatch):
+    """The directory name comes from the formatted timestamp."""
+    monkeypatch.setattr(setup, "RUNS_BASE_DIR", str(tmp_path))
+
+    fixed = MagicMock()
+    fixed.strftime.return_value = "2026-06-05_12-00-00"
+    with patch(f"{_SETUP_MOD}.datetime") as mock_dt:
+        mock_dt.now.return_value = fixed
+        run_dir = setup.setup_run_directory()
+
+    assert run_dir.name == "2026-06-05_12-00-00"
+    assert run_dir == tmp_path / "2026-06-05_12-00-00"
+    fixed.strftime.assert_called_once_with("%Y-%m-%d_%H-%M-%S")
+
+
+def test_setup_run_directory_raises_when_dir_exists(tmp_path, monkeypatch):
+    """mkdir(parents=True) without exist_ok raises on collision."""
+    monkeypatch.setattr(setup, "RUNS_BASE_DIR", str(tmp_path))
+
+    fixed = MagicMock()
+    fixed.strftime.return_value = "collision"
+    (tmp_path / "collision").mkdir()
+
+    with patch(f"{_SETUP_MOD}.datetime") as mock_dt:
+        mock_dt.now.return_value = fixed
+        with pytest.raises(FileExistsError):
+            setup.setup_run_directory()
+
+
+# --------------------------------------------------------------------------- #
+# get_openai_client
+# --------------------------------------------------------------------------- #
+def test_get_openai_client_returns_instance(monkeypatch):
+    """Happy path: a non-empty key yields an OpenAI client instance."""
+    monkeypatch.setattr(openai_client, "OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(openai_client, "_CLIENT", None)
+
+    sentinel = MagicMock(name="OpenAIInstance")
+    fake_openai = MagicMock(return_value=sentinel)
+    monkeypatch.setattr(openai_client, "OpenAI", fake_openai)
+
+    client = openai_client.get_openai_client()
+
+    assert client is sentinel
+    fake_openai.assert_called_once_with(api_key="sk-test")
+
+
+def test_get_openai_client_caches_instance(monkeypatch):
+    """The client is constructed once and reused on subsequent calls."""
+    monkeypatch.setattr(openai_client, "OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(openai_client, "_CLIENT", None)
+
+    fake_openai = MagicMock()
+    monkeypatch.setattr(openai_client, "OpenAI", fake_openai)
+
+    first = openai_client.get_openai_client()
+    second = openai_client.get_openai_client()
+
+    assert first is second
+    fake_openai.assert_called_once()
+
+
+def test_get_openai_client_raises_on_empty_key(monkeypatch):
+    """Error path: an empty API key raises ValueError before constructing."""
+    monkeypatch.setattr(openai_client, "OPENAI_API_KEY", "")
+    monkeypatch.setattr(openai_client, "_CLIENT", None)
+
+    fake_openai = MagicMock()
+    monkeypatch.setattr(openai_client, "OpenAI", fake_openai)
+
+    with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        openai_client.get_openai_client()
+
+    fake_openai.assert_not_called()

--- a/tests/test_video_ffmpeg.py
+++ b/tests/test_video_ffmpeg.py
@@ -1,0 +1,426 @@
+"""Real-ffmpeg tests for VideoAssembler and VideoAudioSyncer.
+
+These exercise the actual ffmpeg/ffprobe subprocess paths. The whole module
+skips when ffmpeg/ffprobe are not available on PATH.
+"""
+
+import base64
+import struct
+import subprocess
+import zlib
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import has_ffmpeg
+from youtube_shorts_gen.media.video_assembler import VideoAssembler
+from youtube_shorts_gen.media.video_audio_sync import VideoAudioSyncer
+
+pytestmark = pytest.mark.skipif(
+    not has_ffmpeg(), reason="ffmpeg not available"
+)
+
+# A 1x1 transparent PNG (decodes cleanly for ffmpeg image input).
+_PNG_1X1 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmM"
+    "IQAAAABJRU5ErkJggg=="
+)
+
+
+def _png_chunk(tag: bytes, data: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(data))
+        + tag
+        + data
+        + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+    )
+
+
+def _write_png(path: Path, size: int = 16) -> Path:
+    """Write a tiny opaque RGB PNG of ``size`` x ``size`` pixels."""
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 2, 0, 0, 0)
+    # One filter byte (0) per row, then size RGB pixels.
+    row = b"\x00" + b"\x40\x80\xc0" * size
+    raw = row * size
+    idat = zlib.compress(raw, 9)
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", ihdr)
+        + _png_chunk(b"IDAT", idat)
+        + _png_chunk(b"IEND", b"")
+    )
+    path.write_bytes(png)
+    return path
+
+
+def _make_image(tmp_path: Path, name: str = "img.png", size: int = 16) -> str:
+    return str(_write_png(tmp_path / name, size))
+
+
+def _make_silent_mp3(path: Path, seconds: int = 2) -> str:
+    """Synthesize a short silent stereo mp3 with ffmpeg."""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=44100:cl=stereo",
+            "-t",
+            str(seconds),
+            "-q:a",
+            "9",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return str(path)
+
+
+# --------------------------------------------------------------------------
+# VideoAssembler._get_audio_duration
+# --------------------------------------------------------------------------
+
+
+def test_get_audio_duration_real_file(tmp_path):
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    duration = assembler._get_audio_duration(audio)
+    assert 1.5 < duration < 2.7
+
+
+def test_get_audio_duration_missing_file_returns_zero(tmp_path):
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    missing = str(tmp_path / "nope.mp3")
+    assert assembler._get_audio_duration(missing) == 0.0
+
+
+# --------------------------------------------------------------------------
+# VideoAssembler.create_segment_video
+# --------------------------------------------------------------------------
+
+
+def test_create_segment_video_happy_path(tmp_path):
+    img = _make_image(tmp_path)
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+
+    out = assembler.create_segment_video(img, audio, index=0)
+
+    assert out
+    out_path = Path(out)
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0
+    assert out_path.name == "segment_1.mp4"
+    # The produced video should be readable by ffprobe with a sane duration.
+    assert assembler._get_video_duration(out) > 1.0
+
+
+def test_create_segment_video_missing_image_returns_empty(tmp_path):
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    out = assembler.create_segment_video(
+        str(tmp_path / "missing.png"), audio, index=0
+    )
+    assert out == ""
+
+
+def test_create_segment_video_missing_audio_returns_empty(tmp_path):
+    img = _make_image(tmp_path)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    out = assembler.create_segment_video(
+        img, str(tmp_path / "missing.mp3"), index=0
+    )
+    assert out == ""
+
+
+# --------------------------------------------------------------------------
+# VideoAssembler.create_video_from_images
+# --------------------------------------------------------------------------
+
+
+def test_create_video_from_images_happy_path(tmp_path):
+    img = _make_image(tmp_path)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    out = assembler.create_video_from_images([img])
+    assert out
+    out_path = Path(out)
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0
+    # Temp processing dir is cleaned up afterwards.
+    assert not (assembler.run_dir / "temp_images").exists()
+
+
+def test_create_video_from_images_empty_list_returns_empty(tmp_path):
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    assert assembler.create_video_from_images([]) == ""
+
+
+def test_create_video_from_images_missing_file_returns_empty(tmp_path):
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    out = assembler.create_video_from_images([str(tmp_path / "gone.png")])
+    assert out == ""
+
+
+# --------------------------------------------------------------------------
+# VideoAssembler.concatenate_segments
+# --------------------------------------------------------------------------
+
+
+def test_concatenate_segments_happy_path(tmp_path):
+    img = _make_image(tmp_path)
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    seg = assembler.create_segment_video(img, audio, index=0)
+    assert seg
+
+    final = assembler.concatenate_segments([seg, seg])
+
+    assert final
+    final_path = Path(final)
+    assert final_path.exists()
+    assert final_path.stat().st_size > 0
+    # Two copies of a ~2s segment -> roughly 4s.
+    assert assembler._get_video_duration(final) > 3.0
+
+
+def test_concatenate_segments_empty_returns_empty(tmp_path):
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    assert assembler.concatenate_segments([]) == ""
+
+
+def test_concatenate_segments_only_invalid_paths_returns_empty(tmp_path):
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    out = assembler.concatenate_segments(["", str(tmp_path / "missing.mp4")])
+    assert out == ""
+
+
+# --------------------------------------------------------------------------
+# VideoAssembler.merge_audio_video + create_looped_video
+# --------------------------------------------------------------------------
+
+
+def test_merge_audio_video_happy_path(tmp_path):
+    img = _make_image(tmp_path)
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    seg = assembler.create_segment_video(img, audio, index=0)
+    assert seg
+
+    out = str(tmp_path / "merged.mp4")
+    result = assembler.merge_audio_video(seg, audio, out)
+
+    assert result == out
+    assert Path(out).exists()
+    assert Path(out).stat().st_size > 0
+
+
+def test_merge_audio_video_missing_video_returns_empty(tmp_path):
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    out = assembler.merge_audio_video(
+        str(tmp_path / "missing.mp4"), audio, str(tmp_path / "o.mp4")
+    )
+    assert out == ""
+
+
+def test_create_looped_video_happy_path(tmp_path):
+    img = _make_image(tmp_path)
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    seg = assembler.create_segment_video(img, audio, index=0)
+    assert seg
+
+    out = str(tmp_path / "looped.mp4")
+    result = assembler.create_looped_video(
+        seg, target_duration=5.0, output_video_path=out
+    )
+
+    assert result == out
+    looped = Path(out)
+    assert looped.exists()
+    # Looping a ~2s clip to reach 5s should produce >= ~6s (ceil(5/2)=3 loops).
+    assert assembler._get_video_duration(out) > 4.0
+    # Concat list temp file is removed in the finally block.
+    assert not (looped.parent / f"loop_list_{looped.stem}.txt").exists()
+
+
+def test_create_looped_video_missing_input_returns_empty(tmp_path):
+    assembler = VideoAssembler(str(tmp_path / "run"))
+    out = assembler.create_looped_video(
+        str(tmp_path / "missing.mp4"), 5.0, str(tmp_path / "o.mp4")
+    )
+    assert out == ""
+
+
+# --------------------------------------------------------------------------
+# VideoAudioSyncer
+# --------------------------------------------------------------------------
+
+
+def test_syncer_get_duration_real_file(tmp_path):
+    audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
+    syncer = VideoAudioSyncer(str(tmp_path))
+    duration = syncer.get_duration(Path(audio))
+    assert isinstance(duration, float)
+    assert 1.5 < duration < 2.7
+
+
+def test_syncer_get_duration_missing_file_raises(tmp_path):
+    syncer = VideoAudioSyncer(str(tmp_path))
+    with pytest.raises(subprocess.CalledProcessError):
+        syncer.get_duration(tmp_path / "missing.mp3")
+
+
+def test_syncer_full_sync_happy_path(tmp_path):
+    """End-to-end sync over a real generated video + audio."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    img = _make_image(run_dir, "img.png")
+    seg_audio = _make_silent_mp3(run_dir / "seg.mp3", seconds=2)
+
+    assembler = VideoAssembler(str(run_dir))
+    seg = assembler.create_segment_video(img, seg_audio, index=0)
+    assert seg
+
+    syncer = VideoAudioSyncer(str(run_dir))
+    # Place the inputs the syncer expects at its configured paths.
+    Path(seg).replace(syncer.input_video)
+    _make_silent_mp3(syncer.audio_path, seconds=3)
+
+    result = syncer.sync()
+
+    assert result == str(syncer.final_video)
+    assert syncer.final_video.exists()
+    assert syncer.final_video.stat().st_size > 0
+
+
+def test_syncer_sync_missing_input_video_raises(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    syncer = VideoAudioSyncer(str(run_dir))
+    _make_silent_mp3(syncer.audio_path, seconds=2)
+    with pytest.raises(FileNotFoundError):
+        syncer.sync()
+
+
+def test_png_fixture_decodes(tmp_path):
+    """Sanity check that the embedded base64 PNG is still valid."""
+    path = tmp_path / "embedded.png"
+    path.write_bytes(base64.b64decode(_PNG_1X1))
+    assert path.stat().st_size > 0
+
+
+# --------------------------------------------------------------------------
+# Smooth timelapse / slideshow / runway-segment (the heaviest ffmpeg paths)
+# --------------------------------------------------------------------------
+
+
+def _nonempty_file(path: str) -> bool:
+    return bool(path) and Path(path).exists() and Path(path).stat().st_size > 0
+
+
+def test_create_smooth_timelapse_with_transitions(tmp_path):
+    """Multi-image timelapse builds a real video via xfade transitions."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    images = [_make_image(tmp_path, f"frame_{i}.png") for i in range(3)]
+
+    out = va.create_smooth_timelapse(
+        images,
+        output_filename="timelapse.mp4",
+        transition_duration=0.2,
+        frame_duration=0.6,
+    )
+
+    assert _nonempty_file(out)
+
+
+def test_create_smooth_timelapse_with_music(tmp_path):
+    """The music path merges a background track over the timelapse."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    images = [_make_image(tmp_path, f"m_{i}.png") for i in range(2)]
+    music = _make_silent_mp3(tmp_path / "bg.mp3", seconds=3)
+
+    out = va.create_smooth_timelapse(
+        images,
+        output_filename="timelapse_music.mp4",
+        transition_duration=0.2,
+        frame_duration=0.6,
+        music_path=music,
+    )
+
+    assert _nonempty_file(out)
+
+
+def test_create_smooth_timelapse_custom_frame_durations(tmp_path):
+    """Per-frame durations are honoured without error."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    images = [_make_image(tmp_path, f"d_{i}.png") for i in range(3)]
+
+    out = va.create_smooth_timelapse(
+        images,
+        output_filename="timelapse_durations.mp4",
+        transition_duration=0.2,
+        frame_durations=[0.5, 0.3, 0.5],
+    )
+
+    assert _nonempty_file(out)
+
+
+def test_create_smooth_timelapse_single_image_fallback(tmp_path):
+    """A single image falls back to a plain (transition-free) video."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    image = _make_image(tmp_path, "solo.png")
+
+    out = va.create_smooth_timelapse([image], output_filename="solo.mp4")
+
+    assert _nonempty_file(out)
+
+
+def test_create_smooth_timelapse_empty_returns_empty(tmp_path):
+    """No images yields an empty string, not a crash."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+
+    assert va.create_smooth_timelapse([]) == ""
+
+
+def test_create_slideshow_video(tmp_path):
+    """A slideshow pairs each image with its narration audio."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    images = [_make_image(tmp_path, f"slide_{i}.png") for i in range(2)]
+    audios = [_make_silent_mp3(tmp_path / f"a_{i}.mp3", seconds=1) for i in range(2)]
+
+    out = va.create_slideshow_video(images, audios, final_video_name="slideshow.mp4")
+
+    assert _nonempty_file(out)
+
+
+def test_create_segment_video_with_runway(tmp_path):
+    """A Runway-style base video is merged with audio into a segment."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    image = _make_image(tmp_path, "rw.png")
+    base_video = va.create_video_from_images(
+        [image], output_filename="rw_base.mp4", fps=4
+    )
+    assert _nonempty_file(base_video)
+    audio = _make_silent_mp3(tmp_path / "rw.mp3", seconds=2)
+
+    out = va.create_segment_video_with_runway(base_video, audio, index=0)
+
+    assert _nonempty_file(out)


### PR DESCRIPTION
Follow-up to the refactor: broaden the test suite, especially the media/upload modules that were previously untested.

## What's added (21 → 137 tests)
9 new test modules. External SDKs (OpenAI, ElevenLabs, RunwayML, Google API, `requests`) are mocked; image tests use **real cv2/PIL**, and the video tests run **real ffmpeg/ffprobe** on tiny synthetic inputs.

- `test_runway` (100%), `test_tts` (100%), `test_openai_image` (89%, cache-isolated), `test_text_processor` (84%), `test_image_ops` (frame_interpolator 94% / image_utils 97%), `test_upload_history` (95%), `test_upload_to_youtube`, `test_utils_misc`
- `test_video_ffmpeg`: drives the real ffmpeg paths in `video_assembler` + `video_audio_sync` — including `create_smooth_timelapse` (the timelapse core, never exercised before), slideshow, runway-segment, looping, and concat. Skips automatically when ffmpeg isn't on PATH.

## Plumbing
- `conftest` ensures ffmpeg is discoverable (system install, else the optional `static-ffmpeg` dev dep)
- dev deps: `pytest-cov`, `static-ffmpeg`; `poetry.lock` re-locked and consistent

## Verification
| check | result |
|---|---|
| ruff | **0** |
| pyright | **0** |
| pytest | **137 passed** |
| coverage | **42% → 73%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)