### PR TITLE
fix: AI pipeline staging + timelapse duration alignment (round-2 review)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def has_ffmpeg() -> bool:
     """Return True if both ffmpeg and ffprobe are available on PATH."""
     return bool(shutil.which("ffmpeg") and shutil.which("ffprobe"))
 
+
 # A 1x1 transparent PNG, base64-encoded, reused by image-generation mocks.
 TEST_IMAGE_B64 = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmM"

--- a/tests/test_openai_image.py
+++ b/tests/test_openai_image.py
@@ -26,9 +26,7 @@ PNG_B64 = (
 def isolate_cache(monkeypatch, tmp_path):
     """Give every test a fresh, on-disk cache index in a temp location."""
     monkeypatch.setattr(openai_image, "_CACHE_INDEX", {})
-    monkeypatch.setattr(
-        openai_image, "_CACHE_INDEX_FILE", tmp_path / "index.json"
-    )
+    monkeypatch.setattr(openai_image, "_CACHE_INDEX_FILE", tmp_path / "index.json")
 
 
 def _make_client(b64=PNG_B64, empty=False):
@@ -95,9 +93,7 @@ def test_generate_image_cache_hit_skips_client(tmp_path, monkeypatch):
     cached_bytes = base64.b64decode(PNG_B64)
     cached.write_bytes(cached_bytes)
 
-    monkeypatch.setattr(
-        openai_image, "_get_cached_path", lambda key: cached
-    )
+    monkeypatch.setattr(openai_image, "_get_cached_path", lambda key: cached)
 
     client = _make_client()
     out = tmp_path / "out.png"

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -6,6 +6,7 @@ TTS, and Runway clips are mocked to produce real local files; ffmpeg, cv2, and
 PIL run for real. The module skips entirely when ffmpeg is unavailable.
 """
 
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -28,8 +29,17 @@ def _png(path: Path, shade: int = 100) -> str:
 def _silent_mp3(path: Path, seconds: int = 2) -> str:
     subprocess.run(
         [
-            "ffmpeg", "-y", "-f", "lavfi", "-i", "anullsrc=r=44100:cl=stereo",
-            "-t", str(seconds), "-q:a", "9", str(path),
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=44100:cl=stereo",
+            "-t",
+            str(seconds),
+            "-q:a",
+            "9",
+            str(path),
         ],
         check=True,
         capture_output=True,
@@ -116,10 +126,17 @@ def test_ai_pipeline_end_to_end(tmp_path):
     run_dir.mkdir()
 
     def make_base_video(*_args, **_kwargs):
+        # Mirror real Runway: write under videos/ and return THAT path. The
+        # pipeline is responsible for staging it to output_story_video.mp4.
         img = _png(run_dir / "vg.png")
-        return VideoAssembler(str(run_dir)).create_video_from_images(
-            [img], output_filename="output_story_video.mp4", fps=4
+        base = VideoAssembler(str(run_dir)).create_video_from_images(
+            [img], output_filename="vg_base.mp4", fps=4
         )
+        videos_dir = run_dir / "videos"
+        videos_dir.mkdir(exist_ok=True)
+        dest = videos_dir / "runway_clip.mp4"
+        shutil.copy(base, dest)
+        return str(dest)
 
     def make_audio(*_args, **_kwargs):
         return _silent_mp3(run_dir / "story_audio.mp3")

--- a/tests/test_text_processor.py
+++ b/tests/test_text_processor.py
@@ -137,9 +137,7 @@ def test_single_large_paragraph_falls_back_to_sentences(tmp_path):
     sentence = "This is a fairly wordy sentence about dragons and knights. "
     text = sentence * 12  # one paragraph, >500 chars, many sentences
 
-    segments = processor.get_content_segments(
-        text, summarize_long_paragraphs=False
-    )
+    segments = processor.get_content_segments(text, summarize_long_paragraphs=False)
 
     assert len(segments) > 1
     assert all(s.endswith(".") for s in segments)

--- a/tests/test_upload_to_youtube.py
+++ b/tests/test_upload_to_youtube.py
@@ -94,18 +94,14 @@ def test_constructor_builds_service_when_creds_present(tmp_path):
     fake_creds = MagicMock()
     fake_service = MagicMock()
     with (
-        patch.object(
-            YouTubeUploader, "_load_credentials", return_value=fake_creds
-        ),
+        patch.object(YouTubeUploader, "_load_credentials", return_value=fake_creds),
         patch(f"{_MODULE}.UploadHistory", return_value=history),
         patch(f"{_MODULE}.build", return_value=fake_service) as mock_build,
     ):
         uploader = YouTubeUploader(str(tmp_path))
 
     assert uploader.youtube is fake_service
-    mock_build.assert_called_once_with(
-        "youtube", "v3", credentials=fake_creds
-    )
+    mock_build.assert_called_once_with("youtube", "v3", credentials=fake_creds)
 
 
 # --------------------------------------------------------------------------- #
@@ -149,9 +145,7 @@ def _drive_successful_upload(uploader, video_id="abc123"):
 
 def test_upload_success_returns_url_and_records_history(tmp_path):
     history_file = tmp_path / "hist.json"
-    uploader, _ = _make_uploader(
-        tmp_path, history_file, creds=MagicMock()
-    )
+    uploader, _ = _make_uploader(tmp_path, history_file, creds=MagicMock())
     _write_story(tmp_path, "first line\nSecond Line Title")
     _write_video(tmp_path)
 
@@ -163,9 +157,7 @@ def test_upload_success_returns_url_and_records_history(tmp_path):
     insert_kwargs = fake_youtube.videos.return_value.insert.call_args.kwargs
     assert insert_kwargs["body"]["snippet"]["title"] == "Second Line Title"
     assert insert_kwargs["part"] == "snippet,status"
-    assert insert_kwargs["body"]["status"]["privacyStatus"] == (
-        YOUTUBE_PRIVACY_STATUS
-    )
+    assert insert_kwargs["body"]["status"]["privacyStatus"] == (YOUTUBE_PRIVACY_STATUS)
 
     # History file updated with the new upload.
     recorded = UploadHistory(history_file=str(history_file)).load_history()
@@ -176,9 +168,7 @@ def test_upload_success_returns_url_and_records_history(tmp_path):
 
 def test_upload_title_falls_back_to_first_line(tmp_path):
     history_file = tmp_path / "hist.json"
-    uploader, _ = _make_uploader(
-        tmp_path, history_file, creds=MagicMock()
-    )
+    uploader, _ = _make_uploader(tmp_path, history_file, creds=MagicMock())
     # Only one line -> the first line is used as the title.
     _write_story(tmp_path, "Only One Line")
     _write_video(tmp_path)
@@ -196,9 +186,7 @@ def test_upload_dedupes_duplicate_title(tmp_path):
     seed = UploadHistory(history_file=str(history_file))
     seed.add_upload("Second Line Title", "https://youtu.be/old", "old story")
 
-    uploader, _ = _make_uploader(
-        tmp_path, history_file, creds=MagicMock()
-    )
+    uploader, _ = _make_uploader(tmp_path, history_file, creds=MagicMock())
     _write_story(tmp_path, "first line\nSecond Line Title")
     _write_video(tmp_path)
 
@@ -217,9 +205,7 @@ def test_upload_dedupes_duplicate_title(tmp_path):
 
 def test_upload_returns_none_when_execute_raises(tmp_path):
     history_file = tmp_path / "hist.json"
-    uploader, _ = _make_uploader(
-        tmp_path, history_file, creds=MagicMock()
-    )
+    uploader, _ = _make_uploader(tmp_path, history_file, creds=MagicMock())
     _write_story(tmp_path, "first line\nSecond Line Title")
     _write_video(tmp_path)
 

--- a/tests/test_video_ffmpeg.py
+++ b/tests/test_video_ffmpeg.py
@@ -16,9 +16,7 @@ from tests.conftest import has_ffmpeg
 from youtube_shorts_gen.media.video_assembler import VideoAssembler
 from youtube_shorts_gen.media.video_audio_sync import VideoAudioSyncer
 
-pytestmark = pytest.mark.skipif(
-    not has_ffmpeg(), reason="ffmpeg not available"
-)
+pytestmark = pytest.mark.skipif(not has_ffmpeg(), reason="ffmpeg not available")
 
 # A 1x1 transparent PNG (decodes cleanly for ffmpeg image input).
 _PNG_1X1 = (
@@ -121,18 +119,14 @@ def test_create_segment_video_happy_path(tmp_path):
 def test_create_segment_video_missing_image_returns_empty(tmp_path):
     audio = _make_silent_mp3(tmp_path / "a.mp3", seconds=2)
     assembler = VideoAssembler(str(tmp_path / "run"))
-    out = assembler.create_segment_video(
-        str(tmp_path / "missing.png"), audio, index=0
-    )
+    out = assembler.create_segment_video(str(tmp_path / "missing.png"), audio, index=0)
     assert out == ""
 
 
 def test_create_segment_video_missing_audio_returns_empty(tmp_path):
     img = _make_image(tmp_path)
     assembler = VideoAssembler(str(tmp_path / "run"))
-    out = assembler.create_segment_video(
-        img, str(tmp_path / "missing.mp3"), index=0
-    )
+    out = assembler.create_segment_video(img, str(tmp_path / "missing.mp3"), index=0)
     assert out == ""
 
 
@@ -441,8 +435,14 @@ def test_crossfade_transition_has_real_duration(tmp_path):
     assert len(clips) == 1
     probe = subprocess.run(
         [
-            "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", clips[0],
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            clips[0],
         ],
         capture_output=True,
         text=True,
@@ -450,3 +450,41 @@ def test_crossfade_transition_has_real_duration(tmp_path):
     )
     # ~0.5s, far above the ~0.033s (one-frame) collapse the old code produced.
     assert float(probe.stdout.strip()) >= 0.4
+
+
+def test_normalise_images_reports_kept_indices(tmp_path):
+    """[bug B] _normalise_images reports kept indices so durations stay aligned."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    img0 = _make_image(tmp_path, "a.png")
+    missing = str(tmp_path / "does_not_exist.png")
+    img2 = _make_image(tmp_path, "c.png")
+    processed_dir = tmp_path / "proc"
+    processed_dir.mkdir()
+
+    result = va._normalise_images([img0, missing, img2], processed_dir, (64, 64))
+
+    assert result is not None
+    processed, kept = result
+    assert kept == [0, 2]  # index 1 (missing) is skipped
+    assert len(processed) == 2
+
+
+def test_smooth_timelapse_with_missing_image_and_durations(tmp_path):
+    """[bug B] A missing image must not crash or misalign custom durations."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    va = VideoAssembler(str(run_dir))
+    images = [
+        _make_image(tmp_path, "f0.png"),
+        str(tmp_path / "missing.png"),
+        _make_image(tmp_path, "f2.png"),
+    ]
+    out = va.create_smooth_timelapse(
+        images,
+        output_filename="tl_missing.mp4",
+        transition_duration=0.2,
+        frame_durations=[0.5, 0.3, 0.5],
+    )
+    assert _nonempty_file(out)

--- a/youtube_shorts_gen/media/video_assembler.py
+++ b/youtube_shorts_gen/media/video_assembler.py
@@ -599,13 +599,17 @@ class VideoAssembler:
         image_paths: list[str],
         processed_dir: Path,
         target_resolution: tuple[int, int],
-    ) -> list[str] | None:
+    ) -> tuple[list[str], list[int]] | None:
         """Scale and pad images to a consistent resolution.
 
-        Returns the list of processed image paths, or None on failure.
+        Returns ``(processed_image_paths, kept_indices)`` — where
+        ``kept_indices`` are the original positions that produced an image (a
+        missing source is skipped) so callers can keep per-frame durations
+        aligned — or ``None`` on a processing failure.
         """
         target_w, target_h = target_resolution
         processed_images: list[str] = []
+        kept_indices: list[int] = []
         for i, img_path in enumerate(image_paths):
             if not os.path.exists(img_path):
                 logging.error("Image file not found: %s", img_path)
@@ -631,10 +635,11 @@ class VideoAssembler:
                     capture_output=True,
                 )
                 processed_images.append(str(output_img))
+                kept_indices.append(i)
             except subprocess.CalledProcessError as e:
                 logging.error("Failed to process image %s: %s", img_path, e.stderr)
                 return None
-        return processed_images
+        return processed_images, kept_indices
 
     def _build_image_clips(
         self,
@@ -826,11 +831,15 @@ class VideoAssembler:
             transitions_dir.mkdir(exist_ok=True)
 
             # Step 1: Process all images to a consistent resolution.
-            processed_images = self._normalise_images(
+            normalised = self._normalise_images(
                 image_paths, processed_dir, target_resolution
             )
-            if processed_images is None:
+            if normalised is None:
                 return ""
+            processed_images, kept_indices = normalised
+            # Keep per-frame durations aligned if any source image was skipped.
+            if frame_durations is not None:
+                frame_durations = [frame_durations[i] for i in kept_indices]
 
             # Step 2: Create individual clips for each image.
             image_clips = self._build_image_clips(

--- a/youtube_shorts_gen/pipelines/ai_content_pipeline.py
+++ b/youtube_shorts_gen/pipelines/ai_content_pipeline.py
@@ -1,6 +1,8 @@
 """AI content pipeline for YouTube shorts generation."""
 
 import logging
+import shutil
+from pathlib import Path
 from typing import Any
 
 from openai import OpenAI
@@ -9,6 +11,7 @@ from youtube_shorts_gen.content.script_and_image_gen import ScriptAndImageGenera
 from youtube_shorts_gen.media.runway import VideoGenerator
 from youtube_shorts_gen.media.tts_generator import TTSGenerator
 from youtube_shorts_gen.media.video_audio_sync import VideoAudioSyncer
+from youtube_shorts_gen.utils.config import OUTPUT_VIDEO_FILENAME
 from youtube_shorts_gen.utils.openai_client import get_openai_client
 
 # === Helper functions (Single Responsibility) ===
@@ -26,11 +29,20 @@ def _generate_script_and_images(run_dir: str, client: OpenAI) -> dict[str, Any]:
 
 
 def _generate_ai_video(run_dir: str) -> dict[str, Any]:
-    """Generate a base video from the images using Runway."""
+    """Generate a base video with Runway and stage it for synchronisation.
+
+    Runway saves its clip under ``<run_dir>/videos/`` and returns that path, but
+    the audio/video syncer reads ``<run_dir>/output_story_video.mp4``. Copy the
+    clip to that expected location so the next step can find it.
+    """
     video_generator = VideoGenerator(run_dir)
     video_path = video_generator.generate()
-    logging.info("[AI Pipeline] Base video generated via Runway: %s", video_path)
-    return {"video_path": video_path}
+    if not video_path:
+        raise RuntimeError("Runway returned no video (generation timed out)")
+    staged_path = Path(run_dir) / OUTPUT_VIDEO_FILENAME
+    shutil.copy(video_path, staged_path)
+    logging.info("[AI Pipeline] Base video staged for sync: %s", staged_path)
+    return {"video_path": str(staged_path)}
 
 
 def _generate_tts(run_dir: str) -> str:


### PR DESCRIPTION
A second adversarial bug-hunt found 2 more real bugs; a third round then confirmed **convergence (0 findings)**. The three rounds converged **11 → 2 → 0**.

## Fixes
- **AI pipeline (HIGH)** — Runway saves its clip under `<run_dir>/videos/` but `VideoAudioSyncer` reads `<run_dir>/output_story_video.mp4`, so the **AI mode (choice 1) could never succeed in production** (it always returned `FileNotFoundError`, swallowed into `success: False`). `_generate_ai_video` now stages the clip to `output_story_video.mp4` and raises if Runway times out (empty return).
  - The earlier integration test *masked* this by writing the staged file directly; it now mirrors real Runway behavior (writes to `videos/`, returns that path) so it actually exercises the staging.
- **Timelapse durations (low)** — `create_smooth_timelapse` misaligned per-frame durations when `_normalise_images` skipped a missing image. `_normalise_images` now returns the kept indices so `frame_durations` is filtered in lockstep.

## Verification
| check | result |
|---|---|
| ruff | **0** |
| pyright | **0** |
| pytest | **153 passed** |
| coverage | **80%** |
| bug-hunt convergence | 11 → 2 → **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)